### PR TITLE
Added Williams single-producer, single-consumer lock-free queue

### DIFF
--- a/cds/container/williams_queue_spsc.h
+++ b/cds/container/williams_queue_spsc.h
@@ -79,6 +79,9 @@ namespace cds { namespace container {
             /// Item allocator. Default is \ref CDS_DEFAULT_ALLOCATOR
             typedef CDS_DEFAULT_ALLOCATOR allocator;
 
+            /// Allocator for std::shared_ptr wrapper. Default is \ref CDS_DEFAULT_ALLOCATOR
+            typedef CDS_DEFAULT_ALLOCATOR node_allocator;
+
             /// Item counting feature; by default, disabled. Use \p cds::atomicity::item_counter to enable item counting
             typedef atomicity::empty_item_counter   item_counter;
 
@@ -214,6 +217,8 @@ namespace cds { namespace container {
         typedef Traits traits;                ///< Queue traits
         typedef typename traits::stat  stat;  ///< Internal statistics
 
+        typedef typename traits::node_allocator      node_allocator_type;
+
     private:
         typedef WilliamsQueue<std::shared_ptr<T>, Traits> parent;
         typedef std::shared_ptr<T> parent_value_type;
@@ -221,7 +226,7 @@ namespace cds { namespace container {
     public:
         /// Enqueues \p val value into the queue.
         bool enqueue(value_type const& val) {
-            return parent::enqueue(std::make_shared<value_type>(val));
+            return parent::enqueue(std::allocate_shared<value_type>(node_allocator_type(), val));
         }
 
         /// Dequeues a value from the queue

--- a/cds/container/williams_queue_spsc.h
+++ b/cds/container/williams_queue_spsc.h
@@ -1,16 +1,16 @@
 //$$CDS-header$$
 
-#ifndef __CDS_INTRUSIVE_WILLIAMS_QUEUE_H
-#define __CDS_INTRUSIVE_WILLIAMS_QUEUE_H
+#ifndef __CDS_CONTAINER_WILLIAMS_QUEUE_H
+#define __CDS_CONTAINER_WILLIAMS_QUEUE_H
 
 #include <memory>
 #include <cds/algo/atomic.h>
 #include <cds/details/allocator.h>
 
-namespace cds { namespace intrusive {
+namespace cds { namespace container {
 
     /// WilliamsQueue related definitions
-    /** @ingroup cds_intrusive_helper
+    /** @ingroup cds_nonintrusive_helper
     */
     namespace williams_queue {
 
@@ -68,6 +68,14 @@ namespace cds { namespace intrusive {
             }
         }
 
+        /// Checks if the queue is empty
+        bool empty() {
+            if (head.load() == tail.load()) {
+                return true;
+            }
+            return false;
+        }
+
         value_type pop() {
             node* old_head = pop_head();
             if (!old_head) {
@@ -88,6 +96,6 @@ namespace cds { namespace intrusive {
         }
     };
 
-}} // namespace cds::intrusive
+}} // namespace cds::container
 
-#endif // #ifndef __CDS_INTRUSIVE_WILLIAMS_QUEUE_H
+#endif // #ifndef __CDS_CONTAINER_WILLIAMS_QUEUE_H

--- a/cds/container/williams_queue_spsc.h
+++ b/cds/container/williams_queue_spsc.h
@@ -14,10 +14,77 @@ namespace cds { namespace container {
     */
     namespace williams_queue {
 
+        /// Queue internal statistics. May be used for debugging or profiling
+        /**
+            Template argument \p Counter defines type of counter.
+            Default is \p cds::atomicity::event_counter, that is weak, i.e. it is not guaranteed
+            strict event counting.
+            You may use stronger type of counter like as \p cds::atomicity::item_counter,
+            or even integral type, for example, \p int.
+        */
+        template <typename Counter = cds::atomicity::event_counter >
+        struct stat
+        {
+            typedef Counter     counter_type;   ///< Counter type
+
+            counter_type m_EnqueueCount      ;  ///< Enqueue call count
+            counter_type m_DequeueCount      ;  ///< Dequeue call count
+            counter_type m_BadTail           ;  ///< Count of events "Tail is not pointed to the last item in the queue"
+
+            /// Register enqueue call
+            void onEnqueue()                { ++m_EnqueueCount; }
+            /// Register dequeue call
+            void onDequeue()                { ++m_DequeueCount; }
+            /// Register event "Tail is not pointed to last item in the queue"
+            void onBadTail()                { ++m_BadTail; }
+
+            //@cond
+            void reset()
+            {
+                m_EnqueueCount.reset();
+                m_DequeueCount.reset();
+                m_BadTail.reset();
+            }
+
+            stat& operator +=( stat const& s )
+            {
+                m_EnqueueCount += s.m_EnqueueCount.get();
+                m_DequeueCount += s.m_DequeueCount.get();
+                m_BadTail += s.m_BadTail.get();
+
+                return *this;
+            }
+            //@endcond
+        };
+
+        /// Dummy queue statistics - no counting is performed, no overhead. Support interface like \p msqueue::stat
+        struct empty_stat
+        {
+            //@cond
+            void onEnqueue()                {}
+            void onDequeue()                {}
+            void onBadTail()                {}
+
+            void reset() {}
+            empty_stat& operator +=( empty_stat const& )
+            {
+                return *this;
+            }
+            //@endcond
+        };
+
         /// WilliamsQueue default traits
         struct traits
         {
+            /// Item allocator. Default is \ref CDS_DEFAULT_ALLOCATOR
             typedef CDS_DEFAULT_ALLOCATOR allocator;
+
+            /// Internal statistics (by default, disabled)
+            /**
+                Possible option value are: \p msqueue::stat, \p msqueue::empty_stat (the default),
+                user-provided class that supports \p %msqueue::stat interface.
+            */
+            typedef williams_queue::empty_stat         stat;
         };
 
     } // namespace williams_queue
@@ -28,6 +95,10 @@ namespace cds { namespace container {
     {
     public:
         typedef std::shared_ptr<T> value_type;
+        typedef Traits traits;                ///< Queue traits
+
+        typedef typename traits::allocator allocator_type;
+        typedef typename traits::stat      stat;           ///< Internal statistics
 
     private:
         struct node {
@@ -38,9 +109,9 @@ namespace cds { namespace container {
             }
         };
 
-        typedef Traits traits;
-        typedef typename traits::allocator allocator_type;
         typedef cds::details::Allocator<node, allocator_type> allocator;
+
+        stat m_Stat;
 
         atomics::atomic<node*> head;
         atomics::atomic<node*> tail;
@@ -48,6 +119,7 @@ namespace cds { namespace container {
         node* pop_head() {
             node * const old_head = head.load();
             if (old_head == tail.load()) {
+                m_Stat.onBadTail();
                 return nullptr;
             }
             head.store(old_head->next);
@@ -55,12 +127,14 @@ namespace cds { namespace container {
         }
     
     public:
+        /// Initializes empty queue
         WilliamsQueue() : head(allocator().New()), tail(head.load()) {
         }
     
         WilliamsQueue(const WilliamsQueue& other) = delete;
         WilliamsQueue& operator=(const WilliamsQueue& other) = delete;
 
+        /// Destructor clears the queue
         ~WilliamsQueue() {
             while (node * const old_head = head.load()) {
                 head.store(old_head->next);
@@ -68,31 +142,40 @@ namespace cds { namespace container {
             }
         }
 
-        /// Checks if the queue is empty
-        bool empty() {
-            if (head.load() == tail.load()) {
-                return true;
-            }
-            return false;
+        /// Enqueues \p val value into the queue.
+        void enqueue(T val) {
+            value_type new_data(std::make_shared<T>(val));
+            node* p = allocator().New();
+            node * const old_tail = tail.load();
+            old_tail->data.swap(new_data);
+            old_tail->next = p;
+            tail.store(p);
+            m_Stat.onEnqueue();
         }
 
-        value_type pop() {
+        /// Dequeues a value from the queue
+        value_type dequeue() {
             node* old_head = pop_head();
             if (!old_head) {
                 return value_type();
             }
             value_type const res(old_head->data);
             allocator().Delete(old_head);
+            m_Stat.onDequeue();
             return res;
         }
 
-        void push(T new_value) {
-            value_type new_data(std::make_shared<T>(new_value));
-            node* p = allocator().New();
-            node * const old_tail = tail.load();
-            old_tail->data.swap(new_data);
-            old_tail->next = p;
-            tail.store(p);
+        /// Checks if the queue is empty
+        bool empty() const {
+            if (head.load() == tail.load()) {
+                return true;
+            }
+            return false;
+        }
+
+        /// Returns reference to internal statistics
+        stat const& statistics() const {
+            return m_Stat;
         }
     };
 

--- a/cds/container/williams_queue_spsc.h
+++ b/cds/container/williams_queue_spsc.h
@@ -115,8 +115,8 @@ namespace cds { namespace container {
             value_type data;
             node* next;
     
-            node() : next(nullptr) {
-            }
+            node() : next(nullptr) 
+            {}
         };
 
         typedef cds::details::Allocator<node, allocator_type> allocator;
@@ -127,7 +127,8 @@ namespace cds { namespace container {
         atomics::atomic<node*> head;
         atomics::atomic<node*> tail;
     
-        node* pop_head() {
+        node* pop_head() 
+        {
             node * const old_head = head.load();
             if (old_head == tail.load()) {
                 m_Stat.onEmptyDequeue();
@@ -139,14 +140,15 @@ namespace cds { namespace container {
     
     public:
         /// Initializes empty queue
-        WilliamsQueue() : head(allocator().New()), tail(head.load()) {
-        }
+        WilliamsQueue() : head(allocator().New()), tail(head.load()) 
+        {}
     
         WilliamsQueue(const WilliamsQueue& other) = delete;
         WilliamsQueue& operator=(const WilliamsQueue& other) = delete;
 
         /// Destructor clears the queue
-        ~WilliamsQueue() {
+        ~WilliamsQueue() 
+        {
             while (node * const old_head = head.load()) {
                 head.store(old_head->next);
                 allocator().Delete(old_head);
@@ -154,7 +156,8 @@ namespace cds { namespace container {
         }
 
         /// Enqueues \p val value into the queue.
-        bool enqueue(value_type val) {
+        bool enqueue(value_type val) 
+        {
             node* p = allocator().New();
             node * const old_tail = tail.load();
             old_tail->data.swap(val);
@@ -165,13 +168,43 @@ namespace cds { namespace container {
             return true;
         }
 
+        /// Enqueues data to the queue using a functor
+        template <typename Func>
+        bool enqueue_with( Func f )
+        {
+            // TODO: implement
+            return false;
+        }
+
+        /// Enqueues data of type \ref value_type constructed from <tt>std::forward<Args>(args)...</tt>
+        template <typename... Args>
+        bool emplace( Args&&... args )
+        {
+            // TODO: implement
+            return false;
+        }
+
+        /// Synonym for \p enqueue() function
+        bool push( value_type const& val ) 
+        {
+            return enqueue( val );
+        }
+
+        /// Synonym for \p enqueue_with() function
+        template <typename Func>
+        bool push_with( Func f )
+        {
+            return enqueue_with( f );
+        }
+
         /// Dequeues a value from the queue
         /**
             If queue is not empty, the function returns \p true, \p dest contains copy of
             dequeued value. The assignment operator for type \ref value_type is invoked.
             If queue is empty, the function returns \p false, \p dest is unchanged.
         */
-        bool dequeue(value_type& dest) {
+        bool dequeue(value_type& dest) 
+        {
             node* old_head = pop_head();
             if (!old_head) {
                 return false;
@@ -183,8 +216,30 @@ namespace cds { namespace container {
             return true;
         }
 
+        /// Dequeues a value using a functor
+        template <typename Func>
+        bool dequeue_with( Func f )
+        {
+            // TODO: implement
+            return false;
+        }
+
+        /// Synonym for \p dequeue() function
+        bool pop( value_type& dest ) 
+        {
+            return dequeue( dest );
+        }
+
+        /// Synonym for \p dequeue_with() function
+        template <typename Func>
+        bool pop_with( Func f )
+        {
+            return dequeue_with( f );
+        }
+
         /// Checks if the queue is empty
-        bool empty() const {
+        bool empty() const 
+        {
             if (head.load() == tail.load()) {
                 return true;
             }
@@ -199,12 +254,14 @@ namespace cds { namespace container {
             @note Even if you use real item counter and it returns 0, this fact is not mean that the queue
             is empty. To check queue emptyness use \p empty() method.
         */
-        size_t size() const {
+        size_t size() const 
+        {
             return m_ItemCounter.value();
         }
 
         /// Returns reference to internal statistics
-        stat const& statistics() const {
+        stat const& statistics() const 
+        {
             return m_Stat;
         }
     };
@@ -225,20 +282,73 @@ namespace cds { namespace container {
 
     public:
         /// Enqueues \p val value into the queue.
-        bool enqueue(value_type const& val) {
+        bool enqueue(value_type const& val) 
+        {
             return parent::enqueue(std::allocate_shared<value_type>(node_allocator_type(), val));
         }
 
+        /// Enqueues data to the queue using a functor
+        template <typename Func>
+        bool enqueue_with( Func f )
+        {
+            // TODO: implement
+            return false;
+        }
+
+        /// Enqueues data of type \ref value_type constructed from <tt>std::forward<Args>(args)...</tt>
+        template <typename... Args>
+        bool emplace( Args&&... args )
+        {
+            // TODO: implement
+            return false;
+        }
+
+        /// Synonym for \p enqueue() function
+        bool push( value_type const& val ) 
+        {
+            return enqueue( val );
+        }
+
+        /// Synonym for \p enqueue_with() function
+        template <typename Func>
+        bool push_with( Func f )
+        {
+            return enqueue_with( f );
+        }
+
         /// Dequeues a value from the queue
-        bool dequeue(value_type& dest) {
+        bool dequeue(value_type& dest) 
+        {
             parent_value_type val;
             bool res = parent::dequeue(val);
             dest = *val.get();
             return res;
         }
 
+        /// Dequeues a value using a functor
+        template <typename Func>
+        bool dequeue_with( Func f )
+        {
+            // TODO: implement
+            return false;
+        }
+
+        /// Synonym for \p dequeue() function
+        bool pop( value_type& dest ) 
+        {
+            return dequeue( dest );
+        }
+
+        /// Synonym for \p dequeue_with() function
+        template <typename Func>
+        bool pop_with( Func f )
+        {
+            return dequeue_with( f );
+        }
+
         /// Checks if the queue is empty
-        bool empty() const {
+        bool empty() const 
+        {
             parent::empty();
         }
 
@@ -250,13 +360,15 @@ namespace cds { namespace container {
             @note Even if you use real item counter and it returns 0, this fact is not mean that the queue
             is empty. To check queue emptyness use \p empty() method.
         */
-        size_t size() const {
+        size_t size() const 
+        {
             return parent::size();
         }
 
 
         /// Returns reference to internal statistics
-        stat const& statistics() const {
+        stat const& statistics() const 
+        {
             return parent::statistics();
         }
     };

--- a/cds/container/williams_queue_spsc.h
+++ b/cds/container/williams_queue_spsc.h
@@ -57,7 +57,7 @@ namespace cds { namespace container {
             //@endcond
         };
 
-        /// Dummy queue statistics - no counting is performed, no overhead. Support interface like \p msqueue::stat
+        /// Dummy queue statistics - no counting is performed, no overhead. Support interface like \p williams_queue::stat
         struct empty_stat
         {
             //@cond
@@ -84,8 +84,8 @@ namespace cds { namespace container {
 
             /// Internal statistics (by default, disabled)
             /**
-                Possible option value are: \p msqueue::stat, \p msqueue::empty_stat (the default),
-                user-provided class that supports \p %msqueue::stat interface.
+                Possible option value are: \p williams_queue::stat, \p williams_queue::empty_stat (the default),
+                user-provided class that supports \p %williams_queue::stat interface.
             */
             typedef williams_queue::empty_stat         stat;
         };
@@ -184,7 +184,7 @@ namespace cds { namespace container {
 
         /// Returns queue's item count
         /**
-            The value returned depends on \p msqueue::traits::item_counter. For \p atomicity::empty_item_counter,
+            The value returned depends on \p williams_queue::traits::item_counter. For \p atomicity::empty_item_counter,
             this function always returns 0.
 
             @note Even if you use real item counter and it returns 0, this fact is not mean that the queue
@@ -230,7 +230,7 @@ namespace cds { namespace container {
 
         /// Returns queue's item count
         /**
-            The value returned depends on \p msqueue::traits::item_counter. For \p atomicity::empty_item_counter,
+            The value returned depends on \p williams_queue::traits::item_counter. For \p atomicity::empty_item_counter,
             this function always returns 0.
 
             @note Even if you use real item counter and it returns 0, this fact is not mean that the queue

--- a/cds/container/williams_queue_spsc.h
+++ b/cds/container/williams_queue_spsc.h
@@ -228,6 +228,19 @@ namespace cds { namespace container {
             parent::empty();
         }
 
+        /// Returns queue's item count
+        /**
+            The value returned depends on \p msqueue::traits::item_counter. For \p atomicity::empty_item_counter,
+            this function always returns 0.
+
+            @note Even if you use real item counter and it returns 0, this fact is not mean that the queue
+            is empty. To check queue emptyness use \p empty() method.
+        */
+        size_t size() const {
+            return parent::size();
+        }
+
+
         /// Returns reference to internal statistics
         stat const& statistics() const {
             return parent::statistics();

--- a/cds/container/williams_queue_spsc.h
+++ b/cds/container/williams_queue_spsc.h
@@ -91,7 +91,10 @@ namespace cds { namespace container {
 
     /// Williams' single-producer, single-consumer lock-free queue
     template<typename T, typename Traits = williams_queue::traits>
-    class WilliamsQueue
+    class WilliamsQueue;
+
+    template<typename T, typename Traits>
+    class WilliamsQueue<std::shared_ptr<T>, Traits>
     {
     public:
         typedef std::shared_ptr<T> value_type;
@@ -143,11 +146,10 @@ namespace cds { namespace container {
         }
 
         /// Enqueues \p val value into the queue.
-        void enqueue(T val) {
-            value_type new_data(std::make_shared<T>(val));
+        void enqueue(value_type val) {
             node* p = allocator().New();
             node * const old_tail = tail.load();
-            old_tail->data.swap(new_data);
+            old_tail->data.swap(val);
             old_tail->next = p;
             tail.store(p);
             m_Stat.onEnqueue();

--- a/cds/intrusive/williams_queue_spsc.h
+++ b/cds/intrusive/williams_queue_spsc.h
@@ -1,0 +1,88 @@
+//$$CDS-header$$
+
+#ifndef __CDS_INTRUSIVE_WILLIAMS_QUEUE_H
+#define __CDS_INTRUSIVE_WILLIAMS_QUEUE_H
+
+#include <memory>
+#include <cds/algo/atomic.h>
+
+namespace cds { namespace intrusive {
+
+    /// WilliamsQueue related definitions
+    /** @ingroup cds_intrusive_helper
+    */
+    namespace williams_queue {
+
+        /// WilliamsQueue default traits
+        struct traits
+        {
+
+        };
+
+    } // namespace williams_queue
+
+    /// Williams' single-producer, single-consumer lock-free queue
+    template<typename T, typename Traits = williams_queue::traits>
+    class WilliamsQueue
+    {
+    public:
+        typedef std::shared_ptr<T> node_data;
+
+    private:
+        struct node {
+            node_data data;
+            node* next;
+    
+            node() : next(nullptr) {
+            }
+        };
+
+        atomics::atomic<node*> head;
+        atomics::atomic<node*> tail;
+    
+        node* pop_head() {
+            node * const old_head = head.load();
+            if (old_head == tail.load()) {
+                return nullptr;
+            }
+            head.store(old_head->next);
+            return old_head;
+        }
+    
+    public:
+        WilliamsQueue() : head(new node), tail(head.load()) {
+        }
+    
+        WilliamsQueue(const WilliamsQueue& other) = delete;
+        WilliamsQueue& operator=(const WilliamsQueue& other) = delete;
+
+        ~WilliamsQueue() {
+            while (node * const old_head = head.load()) {
+                head.store(old_head->next);
+                delete old_head;
+            }
+        }
+
+        node_data pop() {
+            node* old_head = pop_head();
+            if (!old_head) {
+                return node_data();
+            }
+            node_data const res(old_head->data);
+            delete old_head;
+            return res;
+        }
+
+        void push(T new_value) {
+            node_data new_data(std::make_shared<T>(new_value));
+            node* p = new node;
+            node * const old_tail = tail.load();
+            old_tail->data.swap(new_data);
+            old_tail->next = p;
+            tail.store(p);
+        }
+    };
+
+}} // namespace cds::intrusive
+
+#endif // #ifndef __CDS_INTRUSIVE_WILLIAMS_QUEUE_H

--- a/tests/test-hdr/queue/hdr_queue.h
+++ b/tests/test-hdr/queue/hdr_queue.h
@@ -350,6 +350,8 @@ namespace queue {
         void VyukovMPMCCycleQueue_dyn();
         void VyukovMPMCCycleQueue_dyn_ic();
 
+        void WilliamsQueue_SPSC_integral();
+
         CPPUNIT_TEST_SUITE( HdrTestQueue )
             CPPUNIT_TEST(MSQueue_HP);
             CPPUNIT_TEST(MSQueue_HP_relax);
@@ -452,6 +454,8 @@ namespace queue {
             CPPUNIT_TEST( RWQueue_default)
             CPPUNIT_TEST( RWQueue_mutex )
             CPPUNIT_TEST( RWQueue_ic )
+
+            CPPUNIT_TEST( WilliamsQueue_SPSC_integral )
 
         CPPUNIT_TEST_SUITE_END();
 

--- a/tests/test-hdr/queue/hdr_williams_queue_spsc.cpp
+++ b/tests/test-hdr/queue/hdr_williams_queue_spsc.cpp
@@ -1,0 +1,20 @@
+//$$CDS-header$$
+
+#include <cds/container/williams_queue_spsc.h>
+
+#include "queue/hdr_queue.h"
+
+namespace queue {
+
+    void HdrTestQueue::WilliamsQueue_SPSC_integral()
+    {
+        typedef cds::container::WilliamsQueue< int > test_queue;
+        test_no_ic< test_queue >();
+    }
+
+    void HdrTestQueue::WilliamsQueue_SPSC_wrapped()
+    {
+        typedef cds::container::WilliamsQueue< std::shared_ptr<int> > test_queue;
+        test_no_ic< test_queue >();
+    }
+}   // namespace queue

--- a/tests/test-hdr/queue/hdr_williams_queue_spsc.cpp
+++ b/tests/test-hdr/queue/hdr_williams_queue_spsc.cpp
@@ -11,10 +11,4 @@ namespace queue {
         typedef cds::container::WilliamsQueue< int > test_queue;
         test_no_ic< test_queue >();
     }
-
-    void HdrTestQueue::WilliamsQueue_SPSC_wrapped()
-    {
-        typedef cds::container::WilliamsQueue< std::shared_ptr<int> > test_queue;
-        test_no_ic< test_queue >();
-    }
 }   // namespace queue


### PR DESCRIPTION
It's a single-producer, single-consumer lock-free queue.
Please, see the usage example here:
https://github.com/fertkir/libcds_mdp/tree/master/williams_queue_usage_samples
