### PR TITLE
fix build script warning message

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -453,7 +453,7 @@ cxx_debug_options="-D_DEBUG -O0 -g $cxx_debug_options"
 cxx_release_options="-DNDEBUG $cxx_release_optimization $cxx_release_options"
 
 
-if test $BOOST_INCLUDE_PATH != ''; then
+if test 'x$BOOST_INCLUDE_PATH' != 'x'; then
 	buildCXXflags="$buildCXXflags -I$BOOST_INCLUDE_PATH"
 fi
 


### PR DESCRIPTION
При сборке libcds командой (система ubuntu 14.04 lts):
```
bash build.sh -c gcc -x g++ -b 64 -o linux -j 2 --clean
```
получаю следующее сообщение в выводе скрипта:
```
build.sh: line 456: test: !=: unary operator expected
```
Сообщение появляется из-за этой строчки:
```
if test $BOOST_INCLUDE_PATH != ''; then
```
если не указывать путь к заголовкам boost, потому что $BOOST_INCLUDE_PATH раскрывается в пустую строку. Это не приводит ни к каким неприятным последствиям, кроме ненужного сообщения об ошибке в начале вывода скрипта. Чтобы исправить достаточно взять $BOOST_INCLUDE_PATH в кавычки, по аналогии со следующей проверкой в скрипте, так же используется префикс 'x', на случай если кто-то передаст строку начинающуюся с '-' в качестве пути к заголовкам boost.