### PR TITLE
Remote unneeded lock in nogc lazy list find_at_

### DIFF
--- a/cds/intrusive/lazy_list_nogc.h
+++ b/cds/intrusive/lazy_list_nogc.h
@@ -610,7 +610,6 @@ namespace cds { namespace intrusive {
 
             search( pHead, val, pos, cmp );
             if ( pos.pCur != &m_Tail ) {
-                std::unique_lock< typename node_type::lock_type> al( pos.pCur->m_Lock );
                 if ( cmp( *node_traits::to_value_ptr( *pos.pCur ), val ) == 0 )
                 {
                     return iterator( pos.pCur );


### PR DESCRIPTION
Comparator must not modify items in the list, so calls to the comparator don't require the lock in find_at_ method.