### PR TITLE
Fix bug in build script and support -D option.

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -121,6 +121,10 @@ while [ $# -gt 0 ]
         makejobs=$2
 		shift 2
 		;;
+   -D)
+	EXTRA_CXXFLAGS="$EXTRA_CXXFLAGS -D$2"
+		shift 2
+		;;
    -h)
         usage
         exit $ERROR_EXIT_CODE;; 

--- a/build/build.sh
+++ b/build/build.sh
@@ -453,11 +453,11 @@ cxx_debug_options="-D_DEBUG -O0 -g $cxx_debug_options"
 cxx_release_options="-DNDEBUG $cxx_release_optimization $cxx_release_options"
 
 
-if test 'x$BOOST_INCLUDE_PATH' != 'x'; then
+if test "x$BOOST_INCLUDE_PATH" != "x"; then
 	buildCXXflags="$buildCXXflags -I$BOOST_INCLUDE_PATH"
 fi
 
-if test 'x$buildTestLDflags' = 'x'; then
+if test "x$buildTestLDflags" = "x"; then
 	buildTestLDflags=$buildLDflags
 fi
 


### PR DESCRIPTION
This pull request changes single quotes to double quotes in couple of places in the build.sh script, because bash doesn't expand variables inside single quoted strings, so it is actually a bug. Sorry, that i didn't noticed when i fixed exactly same part of the script.

Also this pull request adds support of -D option to the script. Actually, the script help says that the option is supported, while it isn't. So add support of the -D option to the buildscript.