### PR TITLE
Rational resizing policy

### DIFF
--- a/cds/container/striped_set/adapter.h
+++ b/cds/container/striped_set/adapter.h
@@ -180,6 +180,7 @@ namespace cds { namespace container {
         using cds::intrusive::striped_set::adapted_container;
 
         using cds::intrusive::striped_set::load_factor_resizing;
+        using cds::intrusive::striped_set::rational_load_factor_resizing;
         using cds::intrusive::striped_set::single_bucket_size_threshold;
         using cds::intrusive::striped_set::no_resizing;
 

--- a/cds/intrusive/striped_set/resizing_policy.h
+++ b/cds/intrusive/striped_set/resizing_policy.h
@@ -84,6 +84,70 @@ namespace cds { namespace intrusive { namespace striped_set {
         {}
     };
 
+    template <size_t Numerator, size_t Denominator = 1>
+    struct rational_load_factor_resizing
+    {
+        static_assert( Denominator != 0, "Denominator must not be zero" );
+
+        /// Main policy operator returns \p true when resizing is needed
+        template <typename Container, typename Bucket>
+        bool operator ()(
+            size_t nSize,                   ///< Current item count of \p container
+            Container const& container,     ///< Container
+            Bucket const& /*bucket*/        ///< reference to a container's bucket (not used)
+        ) const
+        {
+            return nSize * Denominator > container.bucket_count() * Numerator;
+        }
+
+        /// Resets internal state of the policy (does nothing)
+        void reset()
+        {}
+    };
+
+    template <size_t Denominator>
+    struct rational_load_factor_resizing<0, Denominator>
+    {
+        ///@cond
+        const size_t m_nNumerator;
+        const size_t m_nDenominator;
+        //@endcond
+    public:
+        /// Default ctor, load factor is 1/2
+        rational_load_factor_resizing()
+            : m_nNumerator(1), m_nDenominator(2)
+        {}
+
+        /// Ctor with explicitly defined \p nLoadFactor
+        rational_load_factor_resizing( size_t nNumerator, size_t nDenominator )
+            : m_nNumerator( nNumerator ), m_nDenominator( nDenominator )
+        {}
+
+        /// Copy ctor
+        rational_load_factor_resizing( rational_load_factor_resizing const& src )
+            : m_nNumerator( src.m_nNumerator ), m_nDenominator( src.m_nDenominator )
+        {}
+
+        /// Move ctor
+        rational_load_factor_resizing( rational_load_factor_resizing&& src )
+            : m_nNumerator( src.m_nNumerator ), m_nDenominator( src.m_nDenominator )
+        {}
+
+        /// Main policy operator returns \p true when resizing is needed
+        template <typename Container, typename Bucket>
+        bool operator ()(
+            size_t nSize,                   ///< Current item count of \p container
+            Container const& container,     ///< Container
+            Bucket const& /*bucket*/        ///< reference to a container's bucket (not used)
+        )
+        {
+            return nSize * m_nDenominator > container.bucket_count() * m_nNumerator;
+        }
+
+        /// Resets internal state of the policy (does nothing)
+        void reset()
+        {}
+    };
 
     /// Single bucket threshold resizing policy
     /** @ingroup cds_striped_resizing_policy

--- a/tests/unit/set2/set_defs.h
+++ b/tests/unit/set2/set_defs.h
@@ -664,21 +664,36 @@
     CDSUNIT_DECLARE_TEST(StripedSet_vector) \
     CDSUNIT_DECLARE_TEST(StripedSet_set) \
     CDSUNIT_DECLARE_TEST(StripedSet_hashset) \
-    CDSUNIT_DECLARE_TEST(StripedSet_boost_unordered_set)
+    CDSUNIT_DECLARE_TEST(StripedSet_boost_unordered_set) \
+    CDSUNIT_DECLARE_TEST(StripedSet_rational_list) \
+    CDSUNIT_DECLARE_TEST(StripedSet_rational_vector) \
+    CDSUNIT_DECLARE_TEST(StripedSet_rational_set) \
+    CDSUNIT_DECLARE_TEST(StripedSet_rational_hashset) \
+    CDSUNIT_DECLARE_TEST(StripedSet_rational_boost_unordered_set)
 
 #define CDSUNIT_DEFINE_StripedSet_common( IMPL, C ) \
     TEST_SET(IMPL, C, StripedSet_list) \
     TEST_SET(IMPL, C, StripedSet_vector) \
     TEST_SET(IMPL, C, StripedSet_set) \
     TEST_SET(IMPL, C, StripedSet_hashset) \
-    TEST_SET(IMPL, C, StripedSet_boost_unordered_set)
+    TEST_SET(IMPL, C, StripedSet_boost_unordered_set) \
+    TEST_SET(IMPL, C, StripedSet_rational_list) \
+    TEST_SET(IMPL, C, StripedSet_rational_vector) \
+    TEST_SET(IMPL, C, StripedSet_rational_set) \
+    TEST_SET(IMPL, C, StripedSet_rational_hashset) \
+    TEST_SET(IMPL, C, StripedSet_rational_boost_unordered_set)
 
 #define CDSUNIT_TEST_StripedSet_common \
     CPPUNIT_TEST(StripedSet_list) \
     CPPUNIT_TEST(StripedSet_vector) \
     CPPUNIT_TEST(StripedSet_set) \
     CPPUNIT_TEST(StripedSet_hashset) \
-    CPPUNIT_TEST(StripedSet_boost_unordered_set)
+    CPPUNIT_TEST(StripedSet_boost_unordered_set) \
+    CPPUNIT_TEST(StripedSet_rational_list) \
+    CPPUNIT_TEST(StripedSet_rational_vector) \
+    CPPUNIT_TEST(StripedSet_rational_set) \
+    CPPUNIT_TEST(StripedSet_rational_hashset) \
+    CPPUNIT_TEST(StripedSet_rational_boost_unordered_set)
 
 #if BOOST_VERSION >= 104800
 #   define CDSUNIT_DECLARE_StripedSet_boost_container \
@@ -686,21 +701,36 @@
     CDSUNIT_DECLARE_TEST(StripedSet_boost_slist) \
     CDSUNIT_DECLARE_TEST(StripedSet_boost_vector) \
     CDSUNIT_DECLARE_TEST(StripedSet_boost_stable_vector) \
-    CDSUNIT_DECLARE_TEST(StripedSet_boost_set)
+    CDSUNIT_DECLARE_TEST(StripedSet_boost_set) \
+    CDSUNIT_DECLARE_TEST(StripedSet_rational_boost_list) \
+    CDSUNIT_DECLARE_TEST(StripedSet_rational_boost_slist) \
+    CDSUNIT_DECLARE_TEST(StripedSet_rational_boost_vector) \
+    CDSUNIT_DECLARE_TEST(StripedSet_rational_boost_stable_vector) \
+    CDSUNIT_DECLARE_TEST(StripedSet_rational_boost_set)
 
 #   define CDSUNIT_DEFINE_StripedSet_boost_container( IMPL, C ) \
     TEST_SET(IMPL, C, StripedSet_boost_list) \
     TEST_SET(IMPL, C, StripedSet_boost_slist) \
     TEST_SET(IMPL, C, StripedSet_boost_vector) \
     TEST_SET(IMPL, C, StripedSet_boost_stable_vector) \
-    TEST_SET(IMPL, C, StripedSet_boost_set)
+    TEST_SET(IMPL, C, StripedSet_boost_set) \
+    TEST_SET(IMPL, C, StripedSet_rational_boost_list) \
+    TEST_SET(IMPL, C, StripedSet_rational_boost_slist) \
+    TEST_SET(IMPL, C, StripedSet_rational_boost_vector) \
+    TEST_SET(IMPL, C, StripedSet_rational_boost_stable_vector) \
+    TEST_SET(IMPL, C, StripedSet_rational_boost_set)
 
 #   define CDSUNIT_TEST_StripedSet_boost_container \
     CPPUNIT_TEST(StripedSet_boost_list) \
     CPPUNIT_TEST(StripedSet_boost_slist) \
     CPPUNIT_TEST(StripedSet_boost_vector) \
     CPPUNIT_TEST(StripedSet_boost_stable_vector) \
-    CPPUNIT_TEST(StripedSet_boost_set)
+    CPPUNIT_TEST(StripedSet_boost_set) \
+    CPPUNIT_TEST(StripedSet_rational_boost_list) \
+    CPPUNIT_TEST(StripedSet_rational_boost_slist) \
+    CPPUNIT_TEST(StripedSet_rational_boost_vector) \
+    CPPUNIT_TEST(StripedSet_rational_boost_stable_vector) \
+    CPPUNIT_TEST(StripedSet_rational_boost_set)
 #else
 #   define CDSUNIT_DECLARE_StripedSet_boost_container
 #   define CDSUNIT_DEFINE_StripedSet_boost_container( IMPL, C )
@@ -709,11 +739,14 @@
 
 #if BOOST_VERSION >= 104800 && defined(CDS_UNIT_SET_TYPES_ENABLE_BOOST_FLAT_CONTAINERS)
 #   define CDSUNIT_DECLARE_StripedSet_boost_flat_container \
-    CDSUNIT_DECLARE_TEST(StripedSet_boost_flat_set)
+    CDSUNIT_DECLARE_TEST(StripedSet_boost_flat_set) \
+    CDSUNIT_DECLARE_TEST(StripedSet_rational_boost_flat_set)
 #   define CDSUNIT_DEFINE_StripedSet_boost_flat_container( IMPL, C ) \
-    TEST_SET(IMPL, C, StripedSet_boost_flat_set)
+    TEST_SET(IMPL, C, StripedSet_boost_flat_set) \
+    TEST_SET(IMPL, C, StripedSet_rational_boost_flat_set)
 #   define CDSUNIT_TEST_StripedSet_boost_flat_container \
-    CPPUNIT_TEST(StripedSet_boost_flat_set)
+    CPPUNIT_TEST(StripedSet_boost_flat_set) \
+    CPPUNIT_TEST(StripedSet_rational_boost_flat_set)
 #else
 #   define CDSUNIT_DECLARE_StripedSet_boost_flat_container
 #   define CDSUNIT_DEFINE_StripedSet_boost_flat_container( IMPL, C )
@@ -739,19 +772,34 @@
     CDSUNIT_DECLARE_TEST(RefinableSet_vector) \
     CDSUNIT_DECLARE_TEST(RefinableSet_set) \
     CDSUNIT_DECLARE_TEST(RefinableSet_hashset) \
-    CDSUNIT_DECLARE_TEST(RefinableSet_boost_unordered_set)
+    CDSUNIT_DECLARE_TEST(RefinableSet_boost_unordered_set) \
+    CDSUNIT_DECLARE_TEST(RefinableSet_rational_list) \
+    CDSUNIT_DECLARE_TEST(RefinableSet_rational_vector) \
+    CDSUNIT_DECLARE_TEST(RefinableSet_rational_set) \
+    CDSUNIT_DECLARE_TEST(RefinableSet_rational_hashset) \
+    CDSUNIT_DECLARE_TEST(RefinableSet_rational_boost_unordered_set)
 #define CDSUNIT_DEFINE_RefinableSet_common(IMPL, C) \
     TEST_SET(IMPL, C, RefinableSet_list) \
     TEST_SET(IMPL, C, RefinableSet_vector) \
     TEST_SET(IMPL, C, RefinableSet_set) \
     TEST_SET(IMPL, C, RefinableSet_hashset) \
-    TEST_SET(IMPL, C, RefinableSet_boost_unordered_set)
+    TEST_SET(IMPL, C, RefinableSet_boost_unordered_set) \
+    TEST_SET(IMPL, C, RefinableSet_rational_list) \
+    TEST_SET(IMPL, C, RefinableSet_rational_vector) \
+    TEST_SET(IMPL, C, RefinableSet_rational_set) \
+    TEST_SET(IMPL, C, RefinableSet_rational_hashset) \
+    TEST_SET(IMPL, C, RefinableSet_rational_boost_unordered_set)
 #define CDSUNIT_TEST_RefinableSet_common \
     CPPUNIT_TEST(RefinableSet_list) \
     CPPUNIT_TEST(RefinableSet_vector) \
     CPPUNIT_TEST(RefinableSet_set) \
     CPPUNIT_TEST(RefinableSet_hashset) \
-    CPPUNIT_TEST(RefinableSet_boost_unordered_set)
+    CPPUNIT_TEST(RefinableSet_boost_unordered_set) \
+    CPPUNIT_TEST(RefinableSet_rational_list) \
+    CPPUNIT_TEST(RefinableSet_rational_vector) \
+    CPPUNIT_TEST(RefinableSet_rational_set) \
+    CPPUNIT_TEST(RefinableSet_rational_hashset) \
+    CPPUNIT_TEST(RefinableSet_rational_boost_unordered_set)
 
 #if BOOST_VERSION >= 104800
 #   define CDSUNIT_DECLARE_RefinableSet_boost_container \
@@ -759,19 +807,34 @@
     CDSUNIT_DECLARE_TEST(RefinableSet_boost_slist) \
     CDSUNIT_DECLARE_TEST(RefinableSet_boost_vector) \
     CDSUNIT_DECLARE_TEST(RefinableSet_boost_stable_vector) \
-    CDSUNIT_DECLARE_TEST(RefinableSet_boost_set)
+    CDSUNIT_DECLARE_TEST(RefinableSet_boost_set) \
+    CDSUNIT_DECLARE_TEST(RefinableSet_rational_boost_list) \
+    CDSUNIT_DECLARE_TEST(RefinableSet_rational_boost_slist) \
+    CDSUNIT_DECLARE_TEST(RefinableSet_rational_boost_vector) \
+    CDSUNIT_DECLARE_TEST(RefinableSet_rational_boost_stable_vector) \
+    CDSUNIT_DECLARE_TEST(RefinableSet_rational_boost_set)
 #   define CDSUNIT_DEFINE_RefinableSet_boost_container( IMPL, C ) \
     TEST_SET(IMPL, C, RefinableSet_boost_list) \
     TEST_SET(IMPL, C, RefinableSet_boost_slist) \
     TEST_SET(IMPL, C, RefinableSet_boost_vector) \
     TEST_SET(IMPL, C, RefinableSet_boost_stable_vector) \
-    TEST_SET(IMPL, C, RefinableSet_boost_set)
+    TEST_SET(IMPL, C, RefinableSet_boost_set) \
+    TEST_SET(IMPL, C, RefinableSet_rational_boost_list) \
+    TEST_SET(IMPL, C, RefinableSet_rational_boost_slist) \
+    TEST_SET(IMPL, C, RefinableSet_rational_boost_vector) \
+    TEST_SET(IMPL, C, RefinableSet_rational_boost_stable_vector) \
+    TEST_SET(IMPL, C, RefinableSet_rational_boost_set)
 #   define CDSUNIT_TEST_RefinableSet_boost_container \
     CPPUNIT_TEST(RefinableSet_boost_list) \
     CPPUNIT_TEST(RefinableSet_boost_slist) \
     CPPUNIT_TEST(RefinableSet_boost_vector) \
     CPPUNIT_TEST(RefinableSet_boost_stable_vector) \
-    CPPUNIT_TEST(RefinableSet_boost_set)
+    CPPUNIT_TEST(RefinableSet_boost_set) \
+    CPPUNIT_TEST(RefinableSet_rational_boost_list) \
+    CPPUNIT_TEST(RefinableSet_rational_boost_slist) \
+    CPPUNIT_TEST(RefinableSet_rational_boost_vector) \
+    CPPUNIT_TEST(RefinableSet_rational_boost_stable_vector) \
+    CPPUNIT_TEST(RefinableSet_rational_boost_set)
 #else
 #   define CDSUNIT_DECLARE_RefinableSet_boost_container
 #   define CDSUNIT_DEFINE_RefinableSet_boost_container( IMPL, C ) \
@@ -780,11 +843,14 @@
 
 #if BOOST_VERSION >= 104800 && defined(CDS_UNIT_SET_TYPES_ENABLE_BOOST_FLAT_CONTAINERS)
 #   define CDSUNIT_DECLARE_RefinableSet_boost_flat_container \
-    CDSUNIT_DECLARE_TEST(RefinableSet_boost_flat_set)
+    CDSUNIT_DECLARE_TEST(RefinableSet_boost_flat_set) \
+    CDSUNIT_DECLARE_TEST(RefinableSet_rational_boost_flat_set)
 #   define CDSUNIT_DEFINE_RefinableSet_boost_flat_container( IMPL, C ) \
-    TEST_SET(IMPL, C, RefinableSet_boost_flat_set)
+    TEST_SET(IMPL, C, RefinableSet_boost_flat_set) \
+    TEST_SET(IMPL, C, RefinableSet_rational_boost_flat_set)
 #   define CDSUNIT_TEST_RefinableSet_boost_flat_container \
-    CPPUNIT_TEST(RefinableSet_boost_flat_set)
+    CPPUNIT_TEST(RefinableSet_boost_flat_set) \
+    CPPUNIT_TEST(RefinableSet_rational_boost_flat_set)
 #else
 #   define CDSUNIT_DECLARE_RefinableSet_boost_flat_container
 #   define CDSUNIT_DEFINE_RefinableSet_boost_flat_container( IMPL, C )

--- a/tests/unit/set2/set_type_striped.h
+++ b/tests/unit/set2/set_type_striped.h
@@ -68,6 +68,34 @@ namespace set2 {
             }
         };
 
+        template <class BucketEntry, typename... Options>
+        class StripedHashSet_seq_rational:
+            public cc::StripedSet< BucketEntry,
+                co::mutex_policy< cc::striped_set::striping<> >
+                ,co::resizing_policy<cc::striped_set::rational_load_factor_resizing<0> >
+                , Options...
+            >
+        {
+            typedef cc::StripedSet< BucketEntry,
+                co::mutex_policy< cc::striped_set::striping<> >
+                ,co::resizing_policy<cc::striped_set::rational_load_factor_resizing<0> >
+                , Options...
+            > base_class;
+            typedef typename base_class::resizing_policy resizing_policy_t;
+
+            resizing_policy_t   m_placeHolder;
+        public:
+            StripedHashSet_seq_rational( size_t nCapacity, size_t nDenominator ) // LoadFactor = 1 / nDenominator
+                : base_class( nCapacity * nDenominator / 16, *(new(&m_placeHolder) resizing_policy_t( 1, nDenominator )) )
+            {}
+
+            template <typename Q, typename Less>
+            bool erase_with( Q const& v, Less /*pred*/ )
+            {
+                return base_class::erase( v );
+            }
+        };
+
         // for non-sequential ordered containers
         template <class BucketEntry, typename... Options>
         class StripedHashSet_ord:
@@ -97,17 +125,57 @@ namespace set2 {
             }
         };
 
+        template <class BucketEntry, typename... Options>
+        class StripedHashSet_ord_rational:
+            public cc::StripedSet< BucketEntry,
+                co::resizing_policy<cc::striped_set::rational_load_factor_resizing<0> >
+                ,co::mutex_policy< cc::striped_set::striping<> >
+                , Options...
+            >
+        {
+            typedef cc::StripedSet< BucketEntry,
+               co::resizing_policy<cc::striped_set::rational_load_factor_resizing<0> >
+                ,co::mutex_policy< cc::striped_set::striping<> >
+                , Options...
+            > base_class;
+            typedef typename base_class::resizing_policy resizing_policy_t;
+
+            resizing_policy_t   m_placeHolder;
+        public:
+            StripedHashSet_ord_rational( size_t /*nCapacity*/, size_t nDenominator ) // LoadFactor = 1 / nDenominator
+                : base_class( 0, *(new(&m_placeHolder) resizing_policy_t( 1024, nDenominator )) )
+            {}
+
+            template <typename Q, typename Less>
+            bool erase_with( Q const& v, Less /*pred*/ )
+            {
+                return base_class::erase( v );
+            }
+        };
+
         typedef StripedHashSet_seq<
             std::list< key_val >
             , co::hash< hash2 >
             , co::less< less >
         > StripedSet_list;
 
+        typedef StripedHashSet_seq_rational<
+            std::list< key_val >
+            , co::hash< hash2 >
+            , co::less< less >
+        > StripedSet_rational_list;
+
         typedef StripedHashSet_seq<
             std::vector< key_val >
             , co::hash< hash2 >
             , co::less< less >
         > StripedSet_vector;
+
+        typedef StripedHashSet_seq_rational<
+            std::vector< key_val >
+            , co::hash< hash2 >
+            , co::less< less >
+        > StripedSet_rational_vector;
 
 #if BOOST_VERSION >= 104800
         typedef StripedHashSet_seq<
@@ -116,11 +184,23 @@ namespace set2 {
             , co::less< less >
         > StripedSet_boost_slist;
 
+        typedef StripedHashSet_seq_rational<
+            boost::container::slist< key_val >
+            , co::hash< hash2 >
+            , co::less< less >
+        > StripedSet_rational_boost_slist;
+
         typedef StripedHashSet_seq<
             boost::container::list< key_val >
             , co::hash< hash2 >
             , co::less< less >
         > StripedSet_boost_list;
+
+        typedef StripedHashSet_seq_rational<
+            boost::container::list< key_val >
+            , co::hash< hash2 >
+            , co::less< less >
+        > StripedSet_rational_boost_list;
 
         typedef StripedHashSet_seq<
             boost::container::vector< key_val >
@@ -128,11 +208,23 @@ namespace set2 {
             , co::less< less >
         > StripedSet_boost_vector;
 
+        typedef StripedHashSet_seq_rational<
+            boost::container::vector< key_val >
+            , co::hash< hash2 >
+            , co::less< less >
+        > StripedSet_rational_boost_vector;
+
         typedef StripedHashSet_seq<
             boost::container::stable_vector< key_val >
             , co::hash< hash2 >
             , co::less< less >
         > StripedSet_boost_stable_vector;
+
+        typedef StripedHashSet_seq_rational<
+            boost::container::stable_vector< key_val >
+            , co::hash< hash2 >
+            , co::less< less >
+        > StripedSet_rational_boost_stable_vector;
 #endif
 
         typedef StripedHashSet_ord<
@@ -140,10 +232,20 @@ namespace set2 {
             , co::hash< hash2 >
         > StripedSet_set;
 
+        typedef StripedHashSet_ord_rational<
+            std::set< key_val, less >
+            , co::hash< hash2 >
+        > StripedSet_rational_set;
+
         typedef StripedHashSet_ord<
             std::unordered_set< key_val, hash, equal_to >
             , co::hash< hash2 >
         > StripedSet_hashset;
+
+        typedef StripedHashSet_ord_rational<
+            std::unordered_set< key_val, hash, equal_to >
+            , co::hash< hash2 >
+        > StripedSet_rational_hashset;
 
 #if BOOST_VERSION >= 104800
         typedef StripedHashSet_ord<
@@ -151,16 +253,31 @@ namespace set2 {
             , co::hash< hash2 >
         > StripedSet_boost_set;
 
+        typedef StripedHashSet_ord_rational<
+            boost::container::set< key_val, less >
+            , co::hash< hash2 >
+        > StripedSet_rational_boost_set;
+
         typedef StripedHashSet_ord<
             boost::container::flat_set< key_val, less >
             , co::hash< hash2 >
         > StripedSet_boost_flat_set;
+
+        typedef StripedHashSet_ord_rational<
+            boost::container::flat_set< key_val, less >
+            , co::hash< hash2 >
+        > StripedSet_rational_boost_flat_set;
 #endif
 
         typedef StripedHashSet_ord<
             boost::unordered_set< key_val, hash, equal_to >
             , co::hash< hash2 >
         > StripedSet_boost_unordered_set;
+
+        typedef StripedHashSet_ord_rational<
+            boost::unordered_set< key_val, hash, equal_to >
+            , co::hash< hash2 >
+        > StripedSet_rational_boost_unordered_set;
 
 
         // ***************************************************************************
@@ -186,6 +303,34 @@ namespace set2 {
         public:
             RefinableHashSet_seq( size_t nCapacity, size_t nLoadFactor )
                 : base_class( nCapacity / nLoadFactor / 16, *(new(&m_placeHolder) resizing_policy_t( nLoadFactor )) )
+            {}
+
+            template <typename Q, typename Less>
+            bool erase_with( Q const& v, Less /*pred*/ )
+            {
+                return base_class::erase( v );
+            }
+        };
+
+        template <class BucketEntry, typename... Options>
+        class RefinableHashSet_seq_rational:
+            public cc::StripedSet< BucketEntry,
+            co::mutex_policy< cc::striped_set::refinable<> >
+            ,co::resizing_policy<cc::striped_set::rational_load_factor_resizing<0> >
+            , Options...
+            >
+        {
+            typedef cc::StripedSet< BucketEntry,
+                co::mutex_policy< cc::striped_set::refinable<> >
+                ,co::resizing_policy<cc::striped_set::rational_load_factor_resizing<0> >
+                , Options...
+            > base_class;
+            typedef typename base_class::resizing_policy resizing_policy_t;
+
+            resizing_policy_t   m_placeHolder;
+        public:
+            RefinableHashSet_seq_rational( size_t nCapacity, size_t nDenominator ) // LoadFactor = 1 / nDenominator
+                : base_class( nCapacity * nDenominator / 16, *(new(&m_placeHolder) resizing_policy_t( 1, nDenominator )) )
             {}
 
             template <typename Q, typename Less>
@@ -224,17 +369,57 @@ namespace set2 {
             }
         };
 
+        template <class BucketEntry, typename... Options>
+        class RefinableHashSet_ord_rational:
+            public cc::StripedSet< BucketEntry,
+                co::resizing_policy<cc::striped_set::rational_load_factor_resizing<0> >
+                ,co::mutex_policy< cc::striped_set::refinable<> >
+                , Options...
+            >
+        {
+            typedef cc::StripedSet< BucketEntry,
+                co::resizing_policy<cc::striped_set::rational_load_factor_resizing<0> >
+                ,co::mutex_policy< cc::striped_set::refinable<> >
+                , Options...
+            > base_class;
+            typedef typename base_class::resizing_policy resizing_policy_t;
+
+            resizing_policy_t   m_placeHolder;
+        public:
+            RefinableHashSet_ord_rational( size_t /*nCapacity*/, size_t nDenominator ) // LoadFactor = 1 / nDenominator
+                : base_class( 0, *(new(&m_placeHolder) resizing_policy_t( 1024, nDenominator )) )
+            {}
+
+            template <typename Q, typename Less>
+            bool erase_with( Q const& v, Less /*pred*/ )
+            {
+                return base_class::erase( v );
+            }
+        };
+
         typedef RefinableHashSet_seq<
             std::list< key_val >
             , co::hash< hash2 >
             , co::less< less >
         > RefinableSet_list;
 
+        typedef RefinableHashSet_seq_rational<
+            std::list< key_val >
+            , co::hash< hash2 >
+            , co::less< less >
+        > RefinableSet_rational_list;
+
         typedef RefinableHashSet_seq<
             std::vector< key_val >
             , co::hash< hash2 >
             , co::less< less >
         > RefinableSet_vector;
+
+        typedef RefinableHashSet_seq_rational<
+            std::vector< key_val >
+            , co::hash< hash2 >
+            , co::less< less >
+        > RefinableSet_rational_vector;
 
 #if BOOST_VERSION >= 104800
         typedef RefinableHashSet_seq<
@@ -243,11 +428,23 @@ namespace set2 {
             , co::less< less >
         > RefinableSet_boost_slist;
 
+        typedef RefinableHashSet_seq_rational<
+            boost::container::slist< key_val >
+            , co::hash< hash2 >
+            , co::less< less >
+        > RefinableSet_rational_boost_slist;
+
         typedef RefinableHashSet_seq<
             boost::container::list< key_val >
             , co::hash< hash2 >
             , co::less< less >
         > RefinableSet_boost_list;
+
+        typedef RefinableHashSet_seq_rational<
+            boost::container::list< key_val >
+            , co::hash< hash2 >
+            , co::less< less >
+        > RefinableSet_rational_boost_list;
 
         typedef RefinableHashSet_seq<
             boost::container::vector< key_val >
@@ -255,11 +452,23 @@ namespace set2 {
             , co::less< less >
         > RefinableSet_boost_vector;
 
+        typedef RefinableHashSet_seq_rational<
+            boost::container::vector< key_val >
+            , co::hash< hash2 >
+            , co::less< less >
+        > RefinableSet_rational_boost_vector;
+
         typedef RefinableHashSet_seq<
             boost::container::stable_vector< key_val >
             , co::hash< hash2 >
             , co::less< less >
         > RefinableSet_boost_stable_vector;
+
+        typedef RefinableHashSet_seq_rational<
+            boost::container::stable_vector< key_val >
+            , co::hash< hash2 >
+            , co::less< less >
+        > RefinableSet_rational_boost_stable_vector;
 #endif
 
         typedef RefinableHashSet_ord<
@@ -267,10 +476,20 @@ namespace set2 {
             , co::hash< hash2 >
         > RefinableSet_set;
 
+        typedef RefinableHashSet_ord_rational<
+            std::set< key_val, less >
+            , co::hash< hash2 >
+        > RefinableSet_rational_set;
+
         typedef RefinableHashSet_ord<
             std::unordered_set< key_val, hash, equal_to >
             , co::hash< hash2 >
         > RefinableSet_hashset;
+
+        typedef RefinableHashSet_ord_rational<
+            std::unordered_set< key_val, hash, equal_to >
+            , co::hash< hash2 >
+        > RefinableSet_rational_hashset;
 
 #if BOOST_VERSION >= 104800
         typedef RefinableHashSet_ord<
@@ -278,16 +497,31 @@ namespace set2 {
             , co::hash< hash2 >
         > RefinableSet_boost_set;
 
+        typedef RefinableHashSet_ord_rational<
+            boost::container::set< key_val, less >
+            , co::hash< hash2 >
+        > RefinableSet_rational_boost_set;
+
         typedef RefinableHashSet_ord<
             boost::container::flat_set< key_val, less >
             , co::hash< hash2 >
         > RefinableSet_boost_flat_set;
+
+        typedef RefinableHashSet_ord_rational<
+            boost::container::flat_set< key_val, less >
+            , co::hash< hash2 >
+        > RefinableSet_rational_boost_flat_set;
 #endif
 
         typedef RefinableHashSet_ord<
             boost::unordered_set< key_val, hash, equal_to >
             , co::hash< hash2 >
         > RefinableSet_boost_unordered_set;
+
+        typedef RefinableHashSet_ord_rational<
+            boost::unordered_set< key_val, hash, equal_to >
+            , co::hash< hash2 >
+        > RefinableSet_rational_boost_unordered_set;
     };
 
 } // namespace set2


### PR DESCRIPTION
Even though rational load factor doesn't give significant performance improvement and, actually, may lead to performance degradations (e. g. RefinableSet), for StripedSet it still usefull, because it cost nothing (we have not to pay if we don't use rational load factor) and gives small yet noticeable (5-10%) improvement. So this PR adds rational load factor resizing policy and tests.