### PR TITLE
copy test conf files to bin directory

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,3 +11,6 @@ add_library(${TEST_COMMON} OBJECT ${SOURCES})
 
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/test-hdr)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/unit)
+
+file(GLOB  CONF_FILES data/*.conf)
+file(COPY ${CONF_FILES} DESTINATION ${EXECUTABLE_OUTPUT_PATH})


### PR DESCRIPTION
Small change to CMake build that copies the conf files for unit tests to the bin directory.  