### PR TITLE
Flat combinig add stress and unint tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 /build/Makefile
 /build/build.sh
 /build/sample
+/.cproject
+/.settings/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ if(WITH_TESTS_COVERAGE)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fprofile-arcs -ftest-coverage")
     message(STATUS "Test coverage analysis: activated")
   else()
-	message(WARNING "Compiler is not GNU gcc! Test coverage couldn't be analyzed")
+    message(WARNING "Compiler is not GNU gcc! Test coverage couldn't be analyzed")
   endif()  
 endif(WITH_TESTS_COVERAGE)
 

--- a/test/include/cds_test/fc_hevy_value.h
+++ b/test/include/cds_test/fc_hevy_value.h
@@ -29,7 +29,7 @@ namespace fc_test {
     };
 
     template<int DefaultSize = 10>
-    struct HeavyValue {
+    struct heavy_value {
 
         int value;
 
@@ -39,13 +39,13 @@ namespace fc_test {
         static std::vector<int> pop_buff;
         static size_t buffer_size;
 
-        explicit HeavyValue(int new_value = 0)
+        explicit heavy_value(int new_value = 0)
         : value(new_value),
           nNo(0),
           nWriterNo(0)
         {
         };
-        HeavyValue(const HeavyValue &other)
+        heavy_value(const heavy_value &other)
             : value(other.value),
               nNo(other.nNo),
               nWriterNo(other.nWriterNo)
@@ -63,8 +63,8 @@ namespace fc_test {
         }
     };
     template<int DefaultSize>
-    std::vector<int> HeavyValue< DefaultSize >::pop_buff(DefaultSize, rand());
+    std::vector<int> heavy_value< DefaultSize >::pop_buff(DefaultSize, rand());
     template<int DefaultSize>
-    std::vector<int>::size_type HeavyValue< DefaultSize >::buffer_size = DefaultSize;
+    std::vector<int>::size_type heavy_value< DefaultSize >::buffer_size = DefaultSize;
 }
 #endif /* SOURCE_DIRECTORY__TEST_INCLUDE_CDS_TEST_FC_HEVY_VALUE_H_ */

--- a/test/include/cds_test/fc_hevy_value.h
+++ b/test/include/cds_test/fc_hevy_value.h
@@ -16,60 +16,35 @@ namespace{
     struct HeavyValue {
 
         int value;
-        size_t buffer_size;
 
         size_t nNo;
         size_t nWriterNo;
-        static std::vector<int> pop_buff;
 
-        explicit HeavyValue(int new_value = 0, size_t new_bufer_size = DefaultSize)
+        static std::vector<int> pop_buff;
+        static std::vector<int>::size_type buffer_size;
+
+        explicit HeavyValue(int new_value = 0)
         : value(new_value),
-          buffer_size(new_bufer_size),
           nNo(0),
           nWriterNo(0)
         {
-            if( buffer_size != pop_buff.size() ){
-                pop_buff.resize(buffer_size);
-                for(size_t i = 0; i < buffer_size; ++i)
-                   pop_buff[i] = i;
-            }
         };
         HeavyValue(const HeavyValue &other)
             : value(other.value),
-              buffer_size(other.buffer_size),
               nNo(other.nNo),
               nWriterNo(other.nWriterNo)
         {
-            for(size_t i = 0; i < buffer_size; ++i)
-                pop_buff[i] =  static_cast<int>(std::sqrt(other.pop_buff[i]));
+            for(decltype(buffer_size) i = 0; i < buffer_size; ++i)
+                pop_buff[i] =  static_cast<int>(std::sqrt(other.pop_buff[i]*rand()));
         }
-        void operator=(const int& new_value)
-        {
-            value = new_value;
-        }
-        bool operator==(const int new_value) const
-        {
-            return value == new_value;
-        }
-        bool operator<=(const int new_value) const
-        {
-            return value <= new_value;
-        }
-        bool operator<(const int new_value) const
-        {
-            return value < new_value;
-        }
-        bool operator>(const int new_value) const
-        {
-            return value > new_value;
-        }
-        bool operator>=(const int new_value) const
-        {
-            return value >= new_value;
+        static void setArraySize(decltype(buffer_size) new_size){
+            buffer_size = new_size;
+            pop_buff.resize(buffer_size, rand());
         }
     };
-
     template<int DefaultSize>
-    std::vector<int> HeavyValue< DefaultSize >::pop_buff = {};
+    std::vector<int> HeavyValue< DefaultSize >::pop_buff(DefaultSize, rand());
+    template<int DefaultSize>
+    std::vector<int>::size_type HeavyValue< DefaultSize >::buffer_size = DefaultSize;
 }
 #endif /* SOURCE_DIRECTORY__TEST_INCLUDE_CDS_TEST_FC_HEVY_VALUE_H_ */

--- a/test/include/cds_test/fc_hevy_value.h
+++ b/test/include/cds_test/fc_hevy_value.h
@@ -11,7 +11,23 @@
 #include <math.h>
 #include <vector>
 
-namespace{
+namespace fc_test {
+
+    // SFINAE test
+    template <typename T>
+    class has_set_array_size {
+        typedef char small;
+        class big{char dummy[2];};
+
+        template <typename C, void (C::*) (size_t)> class SFINAE {};
+
+        template <typename C> static small test( SFINAE<C, &C::set_array> * ) ;
+        template <typename C> static big   test(...);
+
+    public:
+        static constexpr bool value = sizeof(test<T>(0)) == sizeof(char) ;
+    };
+
     template<int DefaultSize = 10>
     struct HeavyValue {
 
@@ -21,7 +37,7 @@ namespace{
         size_t nWriterNo;
 
         static std::vector<int> pop_buff;
-        static std::vector<int>::size_type buffer_size;
+        static size_t buffer_size;
 
         explicit HeavyValue(int new_value = 0)
         : value(new_value),
@@ -34,10 +50,14 @@ namespace{
               nNo(other.nNo),
               nWriterNo(other.nWriterNo)
         {
-            for(decltype(buffer_size) i = 0; i < buffer_size; ++i)
+            for(size_t i = 0; i < buffer_size; ++i)
                 pop_buff[i] =  static_cast<int>(std::sqrt(other.pop_buff[i]*rand()));
         }
-        static void setArraySize(decltype(buffer_size) new_size){
+        void set_array(size_t new_size) {
+            set_array_size(new_size);
+        }
+        static void set_array_size(size_t new_size){
+            if (buffer_size == new_size) return;
             buffer_size = new_size;
             pop_buff.resize(buffer_size, rand());
         }

--- a/test/include/cds_test/fc_hevy_value.h
+++ b/test/include/cds_test/fc_hevy_value.h
@@ -1,0 +1,58 @@
+/*
+ * fc_hevy_value.h
+ *
+ *  Created on: 31 авг. 2016 г.
+ *      Author: marsel
+ */
+
+#ifndef SOURCE_DIRECTORY__TEST_INCLUDE_CDS_TEST_FC_HEAVY_VALUE_H_
+#define SOURCE_DIRECTORY__TEST_INCLUDE_CDS_TEST_FC_HEAVY_VALUE_H_
+
+#include <math.h>
+#include <vector>
+
+namespace{
+	template<int DefaultSize = 10000>
+	struct HeavyValue {
+		static std::vector<int> pop_buff;
+		int value;
+		size_t buffer_size;
+
+		size_t nNo;
+		size_t nWriterNo;
+
+		explicit HeavyValue(int new_value = 0, size_t new_bufer_size = DefaultSize)
+		: value(new_value),
+		  buffer_size(new_bufer_size),
+		  nNo(0),
+		  nWriterNo(0)
+
+		{
+			if( buffer_size != pop_buff.size() ){
+				pop_buff.resize(buffer_size);
+			}
+		};
+		HeavyValue(const HeavyValue &other)
+			: value(other.value),
+			  buffer_size(other.buffer_size)
+		{
+			working(other);
+		}
+		void operator=(const int& new_value)
+		{
+			value = new_value;
+		}
+		bool operator==(const int new_value) const
+		{
+			return value == new_value;
+		}
+		void working(const HeavyValue &other) {
+			for (size_t i = 0; i < buffer_size; ++i)
+				pop_buff[i] =  static_cast<int>(std::sqrt(other.pop_buff[i]));
+		}
+	};
+
+	template<int DefaultSize>
+	std::vector<int> HeavyValue< DefaultSize >::pop_buff = {};
+}
+#endif /* SOURCE_DIRECTORY__TEST_INCLUDE_CDS_TEST_FC_HEVY_VALUE_H_ */

--- a/test/include/cds_test/fc_hevy_value.h
+++ b/test/include/cds_test/fc_hevy_value.h
@@ -12,47 +12,64 @@
 #include <vector>
 
 namespace{
-	template<int DefaultSize = 10000>
-	struct HeavyValue {
-		static std::vector<int> pop_buff;
-		int value;
-		size_t buffer_size;
+    template<int DefaultSize = 10>
+    struct HeavyValue {
 
-		size_t nNo;
-		size_t nWriterNo;
+        int value;
+        size_t buffer_size;
 
-		explicit HeavyValue(int new_value = 0, size_t new_bufer_size = DefaultSize)
-		: value(new_value),
-		  buffer_size(new_bufer_size),
-		  nNo(0),
-		  nWriterNo(0)
+        size_t nNo;
+        size_t nWriterNo;
+        static std::vector<int> pop_buff;
 
-		{
-			if( buffer_size != pop_buff.size() ){
-				pop_buff.resize(buffer_size);
-			}
-		};
-		HeavyValue(const HeavyValue &other)
-			: value(other.value),
-			  buffer_size(other.buffer_size)
-		{
-			working(other);
-		}
-		void operator=(const int& new_value)
-		{
-			value = new_value;
-		}
-		bool operator==(const int new_value) const
-		{
-			return value == new_value;
-		}
-		void working(const HeavyValue &other) {
-			for (size_t i = 0; i < buffer_size; ++i)
-				pop_buff[i] =  static_cast<int>(std::sqrt(other.pop_buff[i]));
-		}
-	};
+        explicit HeavyValue(int new_value = 0, size_t new_bufer_size = DefaultSize)
+        : value(new_value),
+          buffer_size(new_bufer_size),
+          nNo(0),
+          nWriterNo(0)
+        {
+            if( buffer_size != pop_buff.size() ){
+                pop_buff.resize(buffer_size);
+                for(size_t i = 0; i < buffer_size; ++i)
+                   pop_buff[i] = i;
+            }
+        };
+        HeavyValue(const HeavyValue &other)
+            : value(other.value),
+              buffer_size(other.buffer_size),
+              nNo(other.nNo),
+              nWriterNo(other.nWriterNo)
+        {
+            for(size_t i = 0; i < buffer_size; ++i)
+                pop_buff[i] =  static_cast<int>(std::sqrt(other.pop_buff[i]));
+        }
+        void operator=(const int& new_value)
+        {
+            value = new_value;
+        }
+        bool operator==(const int new_value) const
+        {
+            return value == new_value;
+        }
+        bool operator<=(const int new_value) const
+        {
+            return value <= new_value;
+        }
+        bool operator<(const int new_value) const
+        {
+            return value < new_value;
+        }
+        bool operator>(const int new_value) const
+        {
+            return value > new_value;
+        }
+        bool operator>=(const int new_value) const
+        {
+            return value >= new_value;
+        }
+    };
 
-	template<int DefaultSize>
-	std::vector<int> HeavyValue< DefaultSize >::pop_buff = {};
+    template<int DefaultSize>
+    std::vector<int> HeavyValue< DefaultSize >::pop_buff = {};
 }
 #endif /* SOURCE_DIRECTORY__TEST_INCLUDE_CDS_TEST_FC_HEVY_VALUE_H_ */

--- a/test/stress/data/test-debug.conf
+++ b/test/stress/data/test-debug.conf
@@ -62,6 +62,8 @@ SegmentedQueue_SegmentSize=64
 ProducerCount=3
 ConsumerCount=3
 QueueSize=100000
+# HeavyValueSize - size of value for flat cobining containers, default 100
+# HeavyValueSize=100
 # SegmentedQueue parameters:
 # SegmentedQueue_Iterate: 
 #    1 - run test iteratively for segment size from 4 up to SegmentedQueue_SegmentSize

--- a/test/stress/data/test.conf
+++ b/test/stress/data/test.conf
@@ -62,6 +62,8 @@ SegmentedQueue_SegmentSize=256
 ConsumerCount=4
 ProducerCount=4
 QueueSize=5000000
+# HeavyValueSize - size of value for flat cobining containers, default 100
+# HeavyValueSize=100
 # SegmentedQueue parameters:
 # SegmentedQueue_Iterate: 
 #    1 - run test iteratively for segment size from 4 up to SegmentedQueue_SegmentSize

--- a/test/stress/queue/CMakeLists.txt
+++ b/test/stress/queue/CMakeLists.txt
@@ -2,12 +2,12 @@ set(PACKAGE_NAME stress-queue)
 
 set(CDSSTRESS_QUEUE_SOURCES
     ../main.cpp
-#    bounded_queue_fulness.cpp
-#    intrusive_push_pop.cpp
-#    pop.cpp
-#    push.cpp
+    bounded_queue_fulness.cpp
+    intrusive_push_pop.cpp
+    pop.cpp
+    push.cpp
     push_pop.cpp
-#    random.cpp
+    random.cpp
 )
 
 include_directories(

--- a/test/stress/queue/CMakeLists.txt
+++ b/test/stress/queue/CMakeLists.txt
@@ -2,12 +2,12 @@ set(PACKAGE_NAME stress-queue)
 
 set(CDSSTRESS_QUEUE_SOURCES
     ../main.cpp
-    bounded_queue_fulness.cpp
-    intrusive_push_pop.cpp
-    pop.cpp
-    push.cpp
+#    bounded_queue_fulness.cpp
+#    intrusive_push_pop.cpp
+#    pop.cpp
+#    push.cpp
     push_pop.cpp
-    random.cpp
+#    random.cpp
 )
 
 include_directories(

--- a/test/stress/queue/push_pop.cpp
+++ b/test/stress/queue/push_pop.cpp
@@ -42,16 +42,19 @@ namespace {
 
     static std::atomic<size_t> s_nProducerDone( 0 );
 
+    struct old_value
+	{
+    	size_t nNo;
+		size_t nWriterNo;
+	};
+
+    template<class Value = old_value>
     class queue_push_pop: public cds_test::stress_fixture
     {
     protected:
-        struct value_type
-        {
-            size_t      nNo;
-            size_t      nWriterNo;
-        };
+		using value_type = Value;
 
-        enum {
+	    enum {
             producer_thread,
             consumer_thread
         };
@@ -318,14 +321,18 @@ namespace {
         //static void TearDownTestCase();
     };
 
-    CDSSTRESS_MSQueue( queue_push_pop )
-    CDSSTRESS_MoirQueue( queue_push_pop )
-    CDSSTRESS_BasketQueue( queue_push_pop )
-    CDSSTRESS_OptimsticQueue( queue_push_pop )
-    CDSSTRESS_FCQueue( queue_push_pop )
-    CDSSTRESS_FCDeque( queue_push_pop )
-    CDSSTRESS_RWQueue( queue_push_pop )
-    CDSSTRESS_StdQueue( queue_push_pop )
+    using value_for_fc_with_heavy_value = queue_push_pop< HeavyValue<10> >;
+    using old_queue_push_pop = queue_push_pop<>;
+
+//    CDSSTRESS_MSQueue( old_queue_push_pop )
+//    CDSSTRESS_MoirQueue( old_queue_push_pop )
+//    CDSSTRESS_BasketQueue( old_queue_push_pop )
+//    CDSSTRESS_OptimsticQueue( old_queue_push_pop )
+//    CDSSTRESS_FCQueue( old_queue_push_pop )
+	CDSSTRESS_FCDeque_HeavyValue( value_for_fc_with_heavy_value )
+//    CDSSTRESS_FCDeque( old_queue_push_pop )
+//    CDSSTRESS_RWQueue( old_queue_push_pop )
+//    CDSSTRESS_StdQueue( old_queue_push_pop )
 
 #undef CDSSTRESS_Queue_F
 #define CDSSTRESS_Queue_F( test_fixture, type_name, level ) \
@@ -337,7 +344,7 @@ namespace {
         test( queue ); \
     }
 
-    CDSSTRESS_VyukovQueue( queue_push_pop )
+    CDSSTRESS_VyukovQueue( old_queue_push_pop )
 
 #undef CDSSTRESS_Queue_F
 
@@ -346,10 +353,10 @@ namespace {
     // SegmentedQueue test
 
     class segmented_queue_push_pop
-        : public queue_push_pop
+        : public queue_push_pop<>
         , public ::testing::WithParamInterface< size_t >
     {
-        typedef queue_push_pop base_class;
+        typedef queue_push_pop<> base_class;
 
     protected:
 

--- a/test/stress/queue/push_pop.cpp
+++ b/test/stress/queue/push_pop.cpp
@@ -321,7 +321,7 @@ namespace {
         //static void TearDownTestCase();
     };
 
-    using value_for_fc_with_heavy_value = queue_push_pop< HeavyValue<10> >;
+    using value_for_fc_with_heavy_value = queue_push_pop< HeavyValue<36000> >;
     using old_queue_push_pop = queue_push_pop<>;
 
 //    CDSSTRESS_MSQueue( old_queue_push_pop )
@@ -329,8 +329,8 @@ namespace {
 //    CDSSTRESS_BasketQueue( old_queue_push_pop )
 //    CDSSTRESS_OptimsticQueue( old_queue_push_pop )
 //    CDSSTRESS_FCQueue( old_queue_push_pop )
-	CDSSTRESS_FCDeque_HeavyValue( value_for_fc_with_heavy_value )
 //    CDSSTRESS_FCDeque( old_queue_push_pop )
+	CDSSTRESS_FCDeque_HeavyValue( value_for_fc_with_heavy_value )
 //    CDSSTRESS_RWQueue( old_queue_push_pop )
 //    CDSSTRESS_StdQueue( old_queue_push_pop )
 
@@ -403,7 +403,7 @@ namespace {
         test< queue_type >(); \
     }
 
-    CDSSTRESS_SegmentedQueue( segmented_queue_push_pop )
+//    CDSSTRESS_SegmentedQueue( segmented_queue_push_pop )
 
     INSTANTIATE_TEST_CASE_P( SQ,
         segmented_queue_push_pop,

--- a/test/stress/queue/push_pop.cpp
+++ b/test/stress/queue/push_pop.cpp
@@ -342,18 +342,18 @@ namespace {
         //static void TearDownTestCase();
     };
 
-    using value_for_fc_with_heavy_value = queue_push_pop< fc_test::HeavyValue<36000> >;
-    using old_queue_push_pop = queue_push_pop<>;
+    using fc_with_heavy_value = queue_push_pop< fc_test::heavy_value<36000> >;
+    using simple_queue_push_pop = queue_push_pop<>;
 
-    CDSSTRESS_MSQueue( old_queue_push_pop )
-    CDSSTRESS_MoirQueue( old_queue_push_pop )
-    CDSSTRESS_BasketQueue( old_queue_push_pop )
-    CDSSTRESS_OptimsticQueue( old_queue_push_pop )
-    CDSSTRESS_FCQueue( old_queue_push_pop )
-    CDSSTRESS_FCDeque( old_queue_push_pop )
-    CDSSTRESS_FCDeque_HeavyValue( value_for_fc_with_heavy_value )
-    CDSSTRESS_RWQueue( old_queue_push_pop )
-    CDSSTRESS_StdQueue( old_queue_push_pop )
+    CDSSTRESS_MSQueue( simple_queue_push_pop )
+    CDSSTRESS_MoirQueue( simple_queue_push_pop )
+    CDSSTRESS_BasketQueue( simple_queue_push_pop )
+    CDSSTRESS_OptimsticQueue( simple_queue_push_pop )
+    CDSSTRESS_FCQueue( simple_queue_push_pop )
+    CDSSTRESS_FCDeque( simple_queue_push_pop )
+    CDSSTRESS_FCDeque_HeavyValue( fc_with_heavy_value )
+    CDSSTRESS_RWQueue( simple_queue_push_pop )
+    CDSSTRESS_StdQueue( simple_queue_push_pop )
 
 #undef CDSSTRESS_Queue_F
 #define CDSSTRESS_Queue_F( test_fixture, type_name, level ) \
@@ -365,7 +365,7 @@ namespace {
         test( queue ); \
     }
 
-    CDSSTRESS_VyukovQueue( old_queue_push_pop )
+    CDSSTRESS_VyukovQueue( simple_queue_push_pop )
 
 #undef CDSSTRESS_Queue_F
 

--- a/test/stress/queue/queue_type.h
+++ b/test/stress/queue/queue_type.h
@@ -695,87 +695,88 @@ namespace cds_test {
     CDSSTRESS_Queue_F( test_fixture, FCQueue_deque,                 0 ) \
     CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_stat,            0 ) \
     CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_wait_ss,         1 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_wait_ss_stat,    0 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_wait_sm,         1 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_wait_sm_stat,    0 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_wait_mm,         1 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_wait_mm_stat,    0 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_elimination,     1 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_elimination_stat,0 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCQueue_list,                  0 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_stat,             0 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_wait_ss,          1 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_wait_ss_stat,     0 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_wait_sm,          1 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_wait_sm_stat,     0 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_wait_mm,          1 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_wait_mm_stat,     0 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_elimination,      1 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_elimination_stat, 0 )
+    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_wait_ss_stat,    0 )
+//    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_wait_sm,         1 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_wait_sm_stat,    0 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_wait_mm,         1 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_wait_mm_stat,    0 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_elimination,     1 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_elimination_stat,0 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCQueue_list,                  0 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_stat,             0 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_wait_ss,          1 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_wait_ss_stat,     0 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_wait_sm,          1 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_wait_sm_stat,     0 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_wait_mm,          1 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_wait_mm_stat,     0 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_elimination,      1 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_elimination_stat, 0 )
+
 
 #define CDSSTRESS_FCDeque( test_fixture ) \
     CDSSTRESS_Queue_F( test_fixture, FCDequeL_default,              0 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeL_mutex,                0 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeL_stat,                 0 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeL_wait_ss,              1 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeL_wait_ss_stat,         0 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeL_wait_sm,              1 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeL_wait_sm_stat,         0 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeL_wait_mm,              1 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeL_wait_mm_stat,         0 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeL_elimination,          1 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeL_elimination_stat,     0 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeL_boost,                1 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeL_boost_stat,           0 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeL_boost_elimination,    1 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeL_boost_elimination_stat, 1 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeR_default,              0 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeR_mutex,                0 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeR_stat,                 0 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeR_wait_ss,              1 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeR_wait_ss_stat,         0 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeR_wait_sm,              1 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeR_wait_sm_stat,         0 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeR_wait_mm,              1 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeR_wait_mm_stat,         0 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeR_elimination,          1 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeR_elimination_stat,     0 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeR_boost,                1 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeR_boost_stat,           0 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeR_boost_elimination,    1 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeR_boost_elimination_stat, 1 )
+    CDSSTRESS_Queue_F( test_fixture, FCDequeL_mutex,                1 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeL_stat,                 1 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeL_wait_ss,              1 )
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeL_wait_ss_stat,         0 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeL_wait_sm,              1 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeL_wait_sm_stat,         0 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeL_wait_mm,              1 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeL_wait_mm_stat,         0 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeL_elimination,          1 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeL_elimination_stat,     0 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeL_boost,                1 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeL_boost_stat,           0 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeL_boost_elimination,    1 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeL_boost_elimination_stat, 1 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_default,              0 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_mutex,                0 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_stat,                 0 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_wait_ss,              1 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_wait_ss_stat,         0 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_wait_sm,              1 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_wait_sm_stat,         0 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_wait_mm,              1 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_wait_mm_stat,         0 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_elimination,          1 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_elimination_stat,     0 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_boost,                1 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_boost_stat,           0 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_boost_elimination,    1 ) \
+//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_boost_elimination_stat, 1 )
 
 #define CDSSTRESS_FCDeque_HeavyValue( test_fixture ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_default,              1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_mutex,                1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_stat,                 1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_ss,              1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_ss_stat,         1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_sm,              1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_sm_stat,         1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_mm,              1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_mm_stat,         1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_elimination,          1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_elimination_stat,     1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_boost,                1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_boost_stat,           1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_boost_elimination,    1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_boost_elimination_stat, 1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_default,              1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_mutex,                1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_stat,                 1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_ss,              1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_ss_stat,         1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_sm,              1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_sm_stat,         1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_mm,              1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_mm_stat,         1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_elimination,          1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_elimination_stat,     1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_boost,                1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_boost_stat,           1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_boost_elimination,    1 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_boost_elimination_stat, 1 )
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_default,              0 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_mutex,                0 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_stat,                 0 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_ss,              1 )
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_ss_stat,         1 ) \
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_sm,              1 ) \
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_sm_stat,         1 ) \
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_mm,              1 ) \
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_mm_stat,         1 ) \
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_elimination,          1 ) \
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_elimination_stat,     1 ) \
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_boost,                1 ) \
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_boost_stat,           1 ) \
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_boost_elimination,    1 ) \
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_boost_elimination_stat, 1 ) \
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_default,              1 ) \
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_mutex,                1 ) \
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_stat,                 1 ) \
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_ss,              1 ) \
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_ss_stat,         1 ) \
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_sm,              1 ) \
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_sm_stat,         1 ) \
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_mm,              1 ) \
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_mm_stat,         1 ) \
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_elimination,          1 ) \
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_elimination_stat,     1 ) \
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_boost,                1 ) \
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_boost_stat,           1 ) \
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_boost_elimination,    1 ) \
+//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_boost_elimination_stat, 1 )
 
 #define CDSSTRESS_RWQueue( test_fixture ) \
     CDSSTRESS_Queue_F( test_fixture, RWQueue_Spin,      0 ) \

--- a/test/stress/queue/queue_type.h
+++ b/test/stress/queue/queue_type.h
@@ -52,6 +52,8 @@
 
 #include <cds_test/stress_test.h>
 #include <cds_test/stat_flat_combining_out.h>
+#include <cds_test/fc_hevy_value.h>
+
 #include "print_stat.h"
 
 namespace queue {
@@ -127,6 +129,56 @@ namespace queue {
 
     } // namespace details
 
+namespace fc_details{
+// FCDeque
+        struct traits_FCDeque_stat:
+            public cds::container::fcdeque::make_traits<
+                cds::opt::stat< cds::container::fcdeque::stat<> >
+            >::type
+        {};
+        struct traits_FCDeque_elimination:
+            public cds::container::fcdeque::make_traits<
+                cds::opt::enable_elimination< true >
+            >::type
+        {};
+        struct traits_FCDeque_elimination_stat:
+            public cds::container::fcdeque::make_traits<
+                cds::opt::stat< cds::container::fcdeque::stat<> >,
+                cds::opt::enable_elimination< true >
+            >::type
+        {};
+        struct traits_FCDeque_mutex:
+            public cds::container::fcdeque::make_traits<
+                cds::opt::lock_type< std::mutex >
+            >::type
+        {};
+
+        struct traits_FCDeque_wait_ss: cds::container::fcdeque::traits
+        {
+            typedef cds::algo::flat_combining::wait_strategy::single_mutex_single_condvar<> wait_strategy;
+        };
+        struct traits_FCDeque_wait_ss_stat: traits_FCDeque_wait_ss
+        {
+            typedef cds::container::fcdeque::stat<> stat;
+        };
+        struct traits_FCDeque_wait_sm: cds::container::fcdeque::traits
+        {
+            typedef cds::algo::flat_combining::wait_strategy::single_mutex_multi_condvar<> wait_strategy;
+        };
+        struct traits_FCDeque_wait_sm_stat: traits_FCDeque_wait_sm
+        {
+            typedef cds::container::fcdeque::stat<> stat;
+        };
+        struct traits_FCDeque_wait_mm: cds::container::fcdeque::traits
+        {
+            typedef cds::algo::flat_combining::wait_strategy::multi_mutex_multi_condvar<> wait_strategy;
+        };
+        struct traits_FCDeque_wait_mm_stat: traits_FCDeque_wait_mm
+        {
+            typedef cds::container::fcdeque::stat<> stat;
+        };
+
+}
     template <typename Value>
     struct Types {
 
@@ -400,87 +452,40 @@ namespace queue {
         typedef cds::container::FCQueue< Value, std::queue<Value, std::list<Value> >, traits_FCQueue_elimination_stat > FCQueue_list_elimination_stat;
 
 
-   // FCDeque
-        struct traits_FCDeque_stat:
-            public cds::container::fcdeque::make_traits<
-                cds::opt::stat< cds::container::fcdeque::stat<> >
-            >::type
-        {};
-        struct traits_FCDeque_elimination:
-            public cds::container::fcdeque::make_traits<
-                cds::opt::enable_elimination< true >
-            >::type
-        {};
-        struct traits_FCDeque_elimination_stat:
-            public cds::container::fcdeque::make_traits<
-                cds::opt::stat< cds::container::fcdeque::stat<> >,
-                cds::opt::enable_elimination< true >
-            >::type
-        {};
-        struct traits_FCDeque_mutex:
-            public cds::container::fcdeque::make_traits<
-                cds::opt::lock_type< std::mutex >
-            >::type
-        {};
-
-        struct traits_FCDeque_wait_ss: cds::container::fcdeque::traits
-        {
-            typedef cds::algo::flat_combining::wait_strategy::single_mutex_single_condvar<> wait_strategy;
-        };
-        struct traits_FCDeque_wait_ss_stat: traits_FCDeque_wait_ss
-        {
-            typedef cds::container::fcdeque::stat<> stat;
-        };
-        struct traits_FCDeque_wait_sm: cds::container::fcdeque::traits
-        {
-            typedef cds::algo::flat_combining::wait_strategy::single_mutex_multi_condvar<> wait_strategy;
-        };
-        struct traits_FCDeque_wait_sm_stat: traits_FCDeque_wait_sm
-        {
-            typedef cds::container::fcdeque::stat<> stat;
-        };
-        struct traits_FCDeque_wait_mm: cds::container::fcdeque::traits
-        {
-            typedef cds::algo::flat_combining::wait_strategy::multi_mutex_multi_condvar<> wait_strategy;
-        };
-        struct traits_FCDeque_wait_mm_stat: traits_FCDeque_wait_mm
-        {
-            typedef cds::container::fcdeque::stat<> stat;
-        };
 
         typedef details::FCDequeL< Value > FCDequeL_default;
-        typedef details::FCDequeL< Value, traits_FCDeque_mutex > FCDequeL_mutex;
-        typedef details::FCDequeL< Value, traits_FCDeque_stat > FCDequeL_stat;
-        typedef details::FCDequeL< Value, traits_FCDeque_wait_ss > FCDequeL_wait_ss;
-        typedef details::FCDequeL< Value, traits_FCDeque_wait_ss_stat > FCDequeL_wait_ss_stat;
-        typedef details::FCDequeL< Value, traits_FCDeque_wait_sm > FCDequeL_wait_sm;
-        typedef details::FCDequeL< Value, traits_FCDeque_wait_sm_stat > FCDequeL_wait_sm_stat;
-        typedef details::FCDequeL< Value, traits_FCDeque_wait_mm > FCDequeL_wait_mm;
-        typedef details::FCDequeL< Value, traits_FCDeque_wait_mm_stat > FCDequeL_wait_mm_stat;
-        typedef details::FCDequeL< Value, traits_FCDeque_elimination > FCDequeL_elimination;
-        typedef details::FCDequeL< Value, traits_FCDeque_elimination_stat > FCDequeL_elimination_stat;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_mutex > FCDequeL_mutex;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_stat > FCDequeL_stat;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_wait_ss > FCDequeL_wait_ss;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_wait_ss_stat > FCDequeL_wait_ss_stat;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_wait_sm > FCDequeL_wait_sm;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_wait_sm_stat > FCDequeL_wait_sm_stat;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_wait_mm > FCDequeL_wait_mm;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_wait_mm_stat > FCDequeL_wait_mm_stat;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_elimination > FCDequeL_elimination;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_elimination_stat > FCDequeL_elimination_stat;
 
         typedef details::FCDequeL< Value, cds::container::fcdeque::traits, boost::container::deque<Value> > FCDequeL_boost;
-        typedef details::FCDequeL< Value, traits_FCDeque_stat, boost::container::deque<Value> > FCDequeL_boost_stat;
-        typedef details::FCDequeL< Value, traits_FCDeque_elimination, boost::container::deque<Value> > FCDequeL_boost_elimination;
-        typedef details::FCDequeL< Value, traits_FCDeque_elimination_stat, boost::container::deque<Value> > FCDequeL_boost_elimination_stat;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_stat, boost::container::deque<Value> > FCDequeL_boost_stat;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_elimination, boost::container::deque<Value> > FCDequeL_boost_elimination;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_elimination_stat, boost::container::deque<Value> > FCDequeL_boost_elimination_stat;
 
         typedef details::FCDequeR< Value > FCDequeR_default;
-        typedef details::FCDequeR< Value, traits_FCDeque_mutex > FCDequeR_mutex;
-        typedef details::FCDequeR< Value, traits_FCDeque_stat > FCDequeR_stat;
-        typedef details::FCDequeR< Value, traits_FCDeque_wait_ss > FCDequeR_wait_ss;
-        typedef details::FCDequeR< Value, traits_FCDeque_wait_ss_stat > FCDequeR_wait_ss_stat;
-        typedef details::FCDequeR< Value, traits_FCDeque_wait_sm > FCDequeR_wait_sm;
-        typedef details::FCDequeR< Value, traits_FCDeque_wait_sm_stat > FCDequeR_wait_sm_stat;
-        typedef details::FCDequeR< Value, traits_FCDeque_wait_mm > FCDequeR_wait_mm;
-        typedef details::FCDequeR< Value, traits_FCDeque_wait_mm_stat > FCDequeR_wait_mm_stat;
-        typedef details::FCDequeR< Value, traits_FCDeque_elimination > FCDequeR_elimination;
-        typedef details::FCDequeR< Value, traits_FCDeque_elimination_stat > FCDequeR_elimination_stat;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_mutex > FCDequeR_mutex;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_stat > FCDequeR_stat;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_wait_ss > FCDequeR_wait_ss;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_wait_ss_stat > FCDequeR_wait_ss_stat;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_wait_sm > FCDequeR_wait_sm;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_wait_sm_stat > FCDequeR_wait_sm_stat;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_wait_mm > FCDequeR_wait_mm;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_wait_mm_stat > FCDequeR_wait_mm_stat;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_elimination > FCDequeR_elimination;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_elimination_stat > FCDequeR_elimination_stat;
 
         typedef details::FCDequeR< Value, cds::container::fcdeque::traits, boost::container::deque<Value> > FCDequeR_boost;
-        typedef details::FCDequeR< Value, traits_FCDeque_stat, boost::container::deque<Value> > FCDequeR_boost_stat;
-        typedef details::FCDequeR< Value, traits_FCDeque_elimination, boost::container::deque<Value> > FCDequeR_boost_elimination;
-        typedef details::FCDequeR< Value, traits_FCDeque_elimination_stat, boost::container::deque<Value> > FCDequeR_boost_elimination_stat;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_stat, boost::container::deque<Value> > FCDequeR_boost_stat;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_elimination, boost::container::deque<Value> > FCDequeR_boost_elimination;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_elimination_stat, boost::container::deque<Value> > FCDequeR_boost_elimination_stat;
 
         // STL
         typedef StdQueue_deque<Value>               StdQueue_deque_Spinlock;
@@ -537,6 +542,43 @@ namespace queue {
         typedef cds::container::SegmentedQueue< cds::gc::DHP, Value, traits_SegmentedQueue_mutex_padding >  SegmentedQueue_DHP_mutex_padding;
         typedef cds::container::SegmentedQueue< cds::gc::DHP, Value, traits_SegmentedQueue_mutex_stat >  SegmentedQueue_DHP_mutex_stat;
     };
+
+    template <typename Value>
+    struct TypesFCHeavyValue {
+    	typedef details::FCDequeL< Value > FCDequeL_HeavyValue_default;
+		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_mutex > FCDequeL_HeavyValue_mutex;
+		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_stat > FCDequeL_HeavyValue_stat;
+		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_wait_ss > FCDequeL_HeavyValue_wait_ss;
+		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_wait_ss_stat > FCDequeL_HeavyValue_wait_ss_stat;
+		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_wait_sm > FCDequeL_HeavyValue_wait_sm;
+		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_wait_sm_stat > FCDequeL_HeavyValue_wait_sm_stat;
+		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_wait_mm > FCDequeL_HeavyValue_wait_mm;
+		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_wait_mm_stat > FCDequeL_HeavyValue_wait_mm_stat;
+		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_elimination > FCDequeL_HeavyValue_elimination;
+		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_elimination_stat > FCDequeL_HeavyValue_elimination_stat;
+
+		typedef details::FCDequeL< Value, cds::container::fcdeque::traits, boost::container::deque<Value> > FCDequeL_HeavyValue_boost;
+		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_stat, boost::container::deque<Value> > FCDequeL_HeavyValue_boost_stat;
+		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_elimination, boost::container::deque<Value> > FCDequeL_HeavyValue_boost_elimination;
+		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_elimination_stat, boost::container::deque<Value> > FCDequeL_HeavyValue_boost_elimination_stat;
+
+		typedef details::FCDequeR< Value > FCDequeR_HeavyValue_default;
+		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_mutex > FCDequeR_HeavyValue_mutex;
+		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_stat > FCDequeR_HeavyValue_stat;
+		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_wait_ss > FCDequeR_HeavyValue_wait_ss;
+		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_wait_ss_stat > FCDequeR_HeavyValue_wait_ss_stat;
+		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_wait_sm > FCDequeR_HeavyValue_wait_sm;
+		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_wait_sm_stat > FCDequeR_HeavyValue_wait_sm_stat;
+		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_wait_mm > FCDequeR_HeavyValue_wait_mm;
+		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_wait_mm_stat > FCDequeR_HeavyValue_wait_mm_stat;
+		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_elimination > FCDequeR_HeavyValue_elimination;
+		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_elimination_stat > FCDequeR_HeavyValue_elimination_stat;
+
+		typedef details::FCDequeR< Value, cds::container::fcdeque::traits, boost::container::deque<Value> > FCDequeR_HeavyValue_boost;
+		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_stat, boost::container::deque<Value> > FCDequeR_HeavyValue_boost_stat;
+		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_elimination, boost::container::deque<Value> > FCDequeR_HeavyValue_boost_elimination;
+		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_elimination_stat, boost::container::deque<Value> > FCDequeR_HeavyValue_boost_elimination_stat;
+    };
 }
 
 
@@ -588,6 +630,15 @@ namespace cds_test {
     { \
         if ( !check_detail_level( level )) return; \
         typedef queue::Types< value_type >::type_name queue_type; \
+        queue_type queue; \
+        test( queue ); \
+    }
+
+#define CDSSTRESS_FCQueue_F( test_fixture, type_name, level ) \
+    TEST_F( test_fixture, type_name ) \
+    { \
+        if ( !check_detail_level( level )) return; \
+        typedef queue::TypesFCHeavyValue< value_type >::type_name queue_type; \
         queue_type queue; \
         test( queue ); \
     }
@@ -693,6 +744,38 @@ namespace cds_test {
     CDSSTRESS_Queue_F( test_fixture, FCDequeR_boost_stat,           0 ) \
     CDSSTRESS_Queue_F( test_fixture, FCDequeR_boost_elimination,    1 ) \
     CDSSTRESS_Queue_F( test_fixture, FCDequeR_boost_elimination_stat, 1 )
+
+#define CDSSTRESS_FCDeque_HeavyValue( test_fixture ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_default,              1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_mutex,                1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_stat,                 1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_ss,              1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_ss_stat,         1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_sm,              1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_sm_stat,         1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_mm,              1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_mm_stat,         1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_elimination,          1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_elimination_stat,     1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_boost,                1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_boost_stat,           1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_boost_elimination,    1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_boost_elimination_stat, 1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_default,              1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_mutex,                1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_stat,                 1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_ss,              1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_ss_stat,         1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_sm,              1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_sm_stat,         1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_mm,              1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_mm_stat,         1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_elimination,          1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_elimination_stat,     1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_boost,                1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_boost_stat,           1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_boost_elimination,    1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_boost_elimination_stat, 1 )
 
 #define CDSSTRESS_RWQueue( test_fixture ) \
     CDSSTRESS_Queue_F( test_fixture, RWQueue_Spin,      0 ) \

--- a/test/stress/queue/queue_type.h
+++ b/test/stress/queue/queue_type.h
@@ -695,88 +695,88 @@ namespace cds_test {
     CDSSTRESS_Queue_F( test_fixture, FCQueue_deque,                 0 ) \
     CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_stat,            0 ) \
     CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_wait_ss,         1 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_wait_ss_stat,    0 )
-//    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_wait_sm,         1 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_wait_sm_stat,    0 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_wait_mm,         1 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_wait_mm_stat,    0 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_elimination,     1 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_elimination_stat,0 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCQueue_list,                  0 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_stat,             0 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_wait_ss,          1 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_wait_ss_stat,     0 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_wait_sm,          1 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_wait_sm_stat,     0 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_wait_mm,          1 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_wait_mm_stat,     0 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_elimination,      1 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_elimination_stat, 0 )
+    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_wait_ss_stat,    0 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_wait_sm,         1 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_wait_sm_stat,    0 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_wait_mm,         1 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_wait_mm_stat,    0 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_elimination,     1 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCQueue_deque_elimination_stat,0 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCQueue_list,                  0 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_stat,             0 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_wait_ss,          1 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_wait_ss_stat,     0 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_wait_sm,          1 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_wait_sm_stat,     0 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_wait_mm,          1 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_wait_mm_stat,     0 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_elimination,      1 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCQueue_list_elimination_stat, 0 )
 
 
 #define CDSSTRESS_FCDeque( test_fixture ) \
     CDSSTRESS_Queue_F( test_fixture, FCDequeL_default,              0 ) \
     CDSSTRESS_Queue_F( test_fixture, FCDequeL_mutex,                1 ) \
     CDSSTRESS_Queue_F( test_fixture, FCDequeL_stat,                 1 ) \
-    CDSSTRESS_Queue_F( test_fixture, FCDequeL_wait_ss,              1 )
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeL_wait_ss_stat,         0 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeL_wait_sm,              1 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeL_wait_sm_stat,         0 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeL_wait_mm,              1 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeL_wait_mm_stat,         0 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeL_elimination,          1 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeL_elimination_stat,     0 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeL_boost,                1 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeL_boost_stat,           0 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeL_boost_elimination,    1 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeL_boost_elimination_stat, 1 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_default,              0 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_mutex,                0 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_stat,                 0 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_wait_ss,              1 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_wait_ss_stat,         0 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_wait_sm,              1 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_wait_sm_stat,         0 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_wait_mm,              1 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_wait_mm_stat,         0 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_elimination,          1 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_elimination_stat,     0 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_boost,                1 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_boost_stat,           0 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_boost_elimination,    1 ) \
-//    CDSSTRESS_Queue_F( test_fixture, FCDequeR_boost_elimination_stat, 1 )
+    CDSSTRESS_Queue_F( test_fixture, FCDequeL_wait_ss,              1 )\
+    CDSSTRESS_Queue_F( test_fixture, FCDequeL_wait_ss_stat,         0 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeL_wait_sm,              1 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeL_wait_sm_stat,         0 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeL_wait_mm,              1 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeL_wait_mm_stat,         0 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeL_elimination,          1 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeL_elimination_stat,     0 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeL_boost,                1 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeL_boost_stat,           0 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeL_boost_elimination,    1 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeL_boost_elimination_stat, 1 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeR_default,              0 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeR_mutex,                0 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeR_stat,                 0 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeR_wait_ss,              1 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeR_wait_ss_stat,         0 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeR_wait_sm,              1 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeR_wait_sm_stat,         0 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeR_wait_mm,              1 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeR_wait_mm_stat,         0 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeR_elimination,          1 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeR_elimination_stat,     0 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeR_boost,                1 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeR_boost_stat,           0 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeR_boost_elimination,    1 ) \
+    CDSSTRESS_Queue_F( test_fixture, FCDequeR_boost_elimination_stat, 1 )
 
 #define CDSSTRESS_FCDeque_HeavyValue( test_fixture ) \
     CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_default,              0 ) \
     CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_mutex,                0 ) \
     CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_stat,                 0 ) \
-    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_ss,              1 )
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_ss_stat,         1 ) \
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_sm,              1 ) \
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_sm_stat,         1 ) \
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_mm,              1 ) \
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_mm_stat,         1 ) \
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_elimination,          1 ) \
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_elimination_stat,     1 ) \
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_boost,                1 ) \
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_boost_stat,           1 ) \
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_boost_elimination,    1 ) \
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_boost_elimination_stat, 1 ) \
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_default,              1 ) \
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_mutex,                1 ) \
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_stat,                 1 ) \
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_ss,              1 ) \
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_ss_stat,         1 ) \
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_sm,              1 ) \
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_sm_stat,         1 ) \
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_mm,              1 ) \
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_mm_stat,         1 ) \
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_elimination,          1 ) \
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_elimination_stat,     1 ) \
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_boost,                1 ) \
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_boost_stat,           1 ) \
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_boost_elimination,    1 ) \
-//    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_boost_elimination_stat, 1 )
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_ss,              1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_ss_stat,         1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_sm,              1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_sm_stat,         1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_mm,              1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_wait_mm_stat,         1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_elimination,          1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_elimination_stat,     1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_boost,                1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_boost_stat,           1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_boost_elimination,    1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeL_HeavyValue_boost_elimination_stat, 1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_default,              1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_mutex,                1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_stat,                 1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_ss,              1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_ss_stat,         1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_sm,              1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_sm_stat,         1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_mm,              1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_wait_mm_stat,         1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_elimination,          1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_elimination_stat,     1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_boost,                1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_boost_stat,           1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_boost_elimination,    1 ) \
+    CDSSTRESS_FCQueue_F( test_fixture, FCDequeR_HeavyValue_boost_elimination_stat, 1 )
 
 #define CDSSTRESS_RWQueue( test_fixture ) \
     CDSSTRESS_Queue_F( test_fixture, RWQueue_Spin,      0 ) \

--- a/test/stress/queue/queue_type.h
+++ b/test/stress/queue/queue_type.h
@@ -545,39 +545,39 @@ namespace fc_details{
 
     template <typename Value>
     struct TypesFCHeavyValue {
-    	typedef details::FCDequeL< Value > FCDequeL_HeavyValue_default;
-		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_mutex > FCDequeL_HeavyValue_mutex;
-		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_stat > FCDequeL_HeavyValue_stat;
-		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_wait_ss > FCDequeL_HeavyValue_wait_ss;
-		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_wait_ss_stat > FCDequeL_HeavyValue_wait_ss_stat;
-		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_wait_sm > FCDequeL_HeavyValue_wait_sm;
-		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_wait_sm_stat > FCDequeL_HeavyValue_wait_sm_stat;
-		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_wait_mm > FCDequeL_HeavyValue_wait_mm;
-		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_wait_mm_stat > FCDequeL_HeavyValue_wait_mm_stat;
-		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_elimination > FCDequeL_HeavyValue_elimination;
-		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_elimination_stat > FCDequeL_HeavyValue_elimination_stat;
+        typedef details::FCDequeL< Value > FCDequeL_HeavyValue_default;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_mutex > FCDequeL_HeavyValue_mutex;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_stat > FCDequeL_HeavyValue_stat;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_wait_ss > FCDequeL_HeavyValue_wait_ss;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_wait_ss_stat > FCDequeL_HeavyValue_wait_ss_stat;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_wait_sm > FCDequeL_HeavyValue_wait_sm;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_wait_sm_stat > FCDequeL_HeavyValue_wait_sm_stat;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_wait_mm > FCDequeL_HeavyValue_wait_mm;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_wait_mm_stat > FCDequeL_HeavyValue_wait_mm_stat;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_elimination > FCDequeL_HeavyValue_elimination;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_elimination_stat > FCDequeL_HeavyValue_elimination_stat;
 
-		typedef details::FCDequeL< Value, cds::container::fcdeque::traits, boost::container::deque<Value> > FCDequeL_HeavyValue_boost;
-		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_stat, boost::container::deque<Value> > FCDequeL_HeavyValue_boost_stat;
-		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_elimination, boost::container::deque<Value> > FCDequeL_HeavyValue_boost_elimination;
-		typedef details::FCDequeL< Value, fc_details::traits_FCDeque_elimination_stat, boost::container::deque<Value> > FCDequeL_HeavyValue_boost_elimination_stat;
+        typedef details::FCDequeL< Value, cds::container::fcdeque::traits, boost::container::deque<Value> > FCDequeL_HeavyValue_boost;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_stat, boost::container::deque<Value> > FCDequeL_HeavyValue_boost_stat;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_elimination, boost::container::deque<Value> > FCDequeL_HeavyValue_boost_elimination;
+        typedef details::FCDequeL< Value, fc_details::traits_FCDeque_elimination_stat, boost::container::deque<Value> > FCDequeL_HeavyValue_boost_elimination_stat;
 
-		typedef details::FCDequeR< Value > FCDequeR_HeavyValue_default;
-		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_mutex > FCDequeR_HeavyValue_mutex;
-		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_stat > FCDequeR_HeavyValue_stat;
-		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_wait_ss > FCDequeR_HeavyValue_wait_ss;
-		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_wait_ss_stat > FCDequeR_HeavyValue_wait_ss_stat;
-		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_wait_sm > FCDequeR_HeavyValue_wait_sm;
-		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_wait_sm_stat > FCDequeR_HeavyValue_wait_sm_stat;
-		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_wait_mm > FCDequeR_HeavyValue_wait_mm;
-		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_wait_mm_stat > FCDequeR_HeavyValue_wait_mm_stat;
-		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_elimination > FCDequeR_HeavyValue_elimination;
-		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_elimination_stat > FCDequeR_HeavyValue_elimination_stat;
+        typedef details::FCDequeR< Value > FCDequeR_HeavyValue_default;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_mutex > FCDequeR_HeavyValue_mutex;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_stat > FCDequeR_HeavyValue_stat;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_wait_ss > FCDequeR_HeavyValue_wait_ss;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_wait_ss_stat > FCDequeR_HeavyValue_wait_ss_stat;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_wait_sm > FCDequeR_HeavyValue_wait_sm;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_wait_sm_stat > FCDequeR_HeavyValue_wait_sm_stat;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_wait_mm > FCDequeR_HeavyValue_wait_mm;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_wait_mm_stat > FCDequeR_HeavyValue_wait_mm_stat;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_elimination > FCDequeR_HeavyValue_elimination;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_elimination_stat > FCDequeR_HeavyValue_elimination_stat;
 
-		typedef details::FCDequeR< Value, cds::container::fcdeque::traits, boost::container::deque<Value> > FCDequeR_HeavyValue_boost;
-		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_stat, boost::container::deque<Value> > FCDequeR_HeavyValue_boost_stat;
-		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_elimination, boost::container::deque<Value> > FCDequeR_HeavyValue_boost_elimination;
-		typedef details::FCDequeR< Value, fc_details::traits_FCDeque_elimination_stat, boost::container::deque<Value> > FCDequeR_HeavyValue_boost_elimination_stat;
+        typedef details::FCDequeR< Value, cds::container::fcdeque::traits, boost::container::deque<Value> > FCDequeR_HeavyValue_boost;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_stat, boost::container::deque<Value> > FCDequeR_HeavyValue_boost_stat;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_elimination, boost::container::deque<Value> > FCDequeR_HeavyValue_boost_elimination;
+        typedef details::FCDequeR< Value, fc_details::traits_FCDeque_elimination_stat, boost::container::deque<Value> > FCDequeR_HeavyValue_boost_elimination_stat;
     };
 }
 

--- a/test/unit/queue/fcqueue.cpp
+++ b/test/unit/queue/fcqueue.cpp
@@ -169,7 +169,7 @@ namespace {
 
 	TEST_F( FCQueue, std_deque_heavy_value )
 	{
-		typedef HeavyValue<> ValueType;
+		typedef fc_test::HeavyValue<> ValueType;
 		typedef cds::container::FCQueue<ValueType> queue_type;
 
 		queue_type q;
@@ -178,7 +178,7 @@ namespace {
 
     TEST_F( FCQueue, std_empty_wait_strategy_heavy_value )
     {
-    	typedef HeavyValue<> ValueType;
+    	typedef fc_test::HeavyValue<> ValueType;
         typedef cds::container::FCQueue<ValueType, std::queue< ValueType, std::deque<ValueType>>,
             cds::container::fcqueue::make_traits<
                 cds::opt::wait_strategy< cds::algo::flat_combining::wait_strategy::empty >
@@ -191,7 +191,7 @@ namespace {
 
     TEST_F( FCQueue, std_single_mutex_single_condvar_heavy_value )
     {
-    	typedef HeavyValue<> ValueType;
+    	typedef fc_test::HeavyValue<> ValueType;
         typedef cds::container::FCQueue<ValueType, std::queue< ValueType, std::deque<ValueType>>,
             cds::container::fcqueue::make_traits<
                 cds::opt::wait_strategy< cds::algo::flat_combining::wait_strategy::single_mutex_single_condvar<> >
@@ -204,7 +204,7 @@ namespace {
 
     TEST_F( FCQueue, std_single_mutex_multi_condvar_heavy_value )
     {
-    	typedef HeavyValue<> ValueType;
+    	typedef fc_test::HeavyValue<> ValueType;
         typedef cds::container::FCQueue<ValueType, std::queue< ValueType, std::deque<ValueType>>,
             cds::container::fcqueue::make_traits<
                 cds::opt::wait_strategy< cds::algo::flat_combining::wait_strategy::single_mutex_multi_condvar<> >
@@ -217,7 +217,7 @@ namespace {
 
     TEST_F( FCQueue, std_multi_mutex_multi_condvar_heavy_value )
     {
-    	typedef HeavyValue<> ValueType;
+    	typedef fc_test::HeavyValue<> ValueType;
         typedef cds::container::FCQueue<ValueType, std::queue< ValueType, std::deque<ValueType>>,
             cds::container::fcqueue::make_traits<
                 cds::opt::wait_strategy< cds::algo::flat_combining::wait_strategy::multi_mutex_multi_condvar<> >

--- a/test/unit/queue/fcqueue.cpp
+++ b/test/unit/queue/fcqueue.cpp
@@ -30,50 +30,11 @@
 
 #include <gtest/gtest.h>
 #include <cds/container/fcqueue.h>
+#include <test/include/cds_test/fc_hevy_value.h>
 
 #include <list>
-#include <math.h>
-#include <vector>
 
 namespace {
-
-	template<int DefaultSize = 10000>
-	struct HeavyValue {
-		static std::vector<int> pop_buff;
-		int value;
-		size_t buffer_size;
-
-		explicit HeavyValue(int new_value = 0, size_t new_bufer_size = DefaultSize)
-		: value(new_value),
-		  buffer_size(new_bufer_size)
-
-		{
-			if( buffer_size != pop_buff.size() ){
-				pop_buff.resize(buffer_size);
-			}
-		};
-		HeavyValue(const HeavyValue &other)
-			: value(other.value),
-			  buffer_size(other.buffer_size)
-		{
-			working(other);
-		}
-		void operator=(const int& new_value)
-		{
-			value = new_value;
-		}
-		bool operator==(const int new_value) const
-		{
-			return value == new_value;
-		}
-		void working(const HeavyValue &other) {
-			for (size_t i = 0; i < buffer_size; ++i)
-				pop_buff[i] =  static_cast<int>(std::sqrt(other.pop_buff[i]));
-		}
-	};
-
-	template<int DefaultSize>
-	std::vector<int> HeavyValue< DefaultSize >::pop_buff = {};
 
     class FCQueue: public ::testing::Test
     {

--- a/test/unit/queue/fcqueue.cpp
+++ b/test/unit/queue/fcqueue.cpp
@@ -167,18 +167,18 @@ namespace {
         test( q );
     }
 
-	TEST_F( FCQueue, std_deque_heavy_value )
-	{
-		typedef fc_test::heavy_value<> ValueType;
-		typedef cds::container::FCQueue<ValueType> queue_type;
+    TEST_F( FCQueue, std_deque_heavy_value )
+    {
+        typedef fc_test::heavy_value<> ValueType;
+        typedef cds::container::FCQueue<ValueType> queue_type;
 
-		queue_type q;
-		test( q );
-	}
+        queue_type q;
+        test( q );
+    }
 
     TEST_F( FCQueue, std_empty_wait_strategy_heavy_value )
     {
-    	typedef fc_test::heavy_value<> ValueType;
+        typedef fc_test::heavy_value<> ValueType;
         typedef cds::container::FCQueue<ValueType, std::queue< ValueType, std::deque<ValueType>>,
             cds::container::fcqueue::make_traits<
                 cds::opt::wait_strategy< cds::algo::flat_combining::wait_strategy::empty >
@@ -191,7 +191,7 @@ namespace {
 
     TEST_F( FCQueue, std_single_mutex_single_condvar_heavy_value )
     {
-    	typedef fc_test::heavy_value<> ValueType;
+        typedef fc_test::heavy_value<> ValueType;
         typedef cds::container::FCQueue<ValueType, std::queue< ValueType, std::deque<ValueType>>,
             cds::container::fcqueue::make_traits<
                 cds::opt::wait_strategy< cds::algo::flat_combining::wait_strategy::single_mutex_single_condvar<> >
@@ -204,7 +204,7 @@ namespace {
 
     TEST_F( FCQueue, std_single_mutex_multi_condvar_heavy_value )
     {
-    	typedef fc_test::heavy_value<> ValueType;
+        typedef fc_test::heavy_value<> ValueType;
         typedef cds::container::FCQueue<ValueType, std::queue< ValueType, std::deque<ValueType>>,
             cds::container::fcqueue::make_traits<
                 cds::opt::wait_strategy< cds::algo::flat_combining::wait_strategy::single_mutex_multi_condvar<> >
@@ -217,7 +217,7 @@ namespace {
 
     TEST_F( FCQueue, std_multi_mutex_multi_condvar_heavy_value )
     {
-    	typedef fc_test::heavy_value<> ValueType;
+        typedef fc_test::heavy_value<> ValueType;
         typedef cds::container::FCQueue<ValueType, std::queue< ValueType, std::deque<ValueType>>,
             cds::container::fcqueue::make_traits<
                 cds::opt::wait_strategy< cds::algo::flat_combining::wait_strategy::multi_mutex_multi_condvar<> >

--- a/test/unit/queue/fcqueue.cpp
+++ b/test/unit/queue/fcqueue.cpp
@@ -169,7 +169,7 @@ namespace {
 
 	TEST_F( FCQueue, std_deque_heavy_value )
 	{
-		typedef fc_test::HeavyValue<> ValueType;
+		typedef fc_test::heavy_value<> ValueType;
 		typedef cds::container::FCQueue<ValueType> queue_type;
 
 		queue_type q;
@@ -178,7 +178,7 @@ namespace {
 
     TEST_F( FCQueue, std_empty_wait_strategy_heavy_value )
     {
-    	typedef fc_test::HeavyValue<> ValueType;
+    	typedef fc_test::heavy_value<> ValueType;
         typedef cds::container::FCQueue<ValueType, std::queue< ValueType, std::deque<ValueType>>,
             cds::container::fcqueue::make_traits<
                 cds::opt::wait_strategy< cds::algo::flat_combining::wait_strategy::empty >
@@ -191,7 +191,7 @@ namespace {
 
     TEST_F( FCQueue, std_single_mutex_single_condvar_heavy_value )
     {
-    	typedef fc_test::HeavyValue<> ValueType;
+    	typedef fc_test::heavy_value<> ValueType;
         typedef cds::container::FCQueue<ValueType, std::queue< ValueType, std::deque<ValueType>>,
             cds::container::fcqueue::make_traits<
                 cds::opt::wait_strategy< cds::algo::flat_combining::wait_strategy::single_mutex_single_condvar<> >
@@ -204,7 +204,7 @@ namespace {
 
     TEST_F( FCQueue, std_single_mutex_multi_condvar_heavy_value )
     {
-    	typedef fc_test::HeavyValue<> ValueType;
+    	typedef fc_test::heavy_value<> ValueType;
         typedef cds::container::FCQueue<ValueType, std::queue< ValueType, std::deque<ValueType>>,
             cds::container::fcqueue::make_traits<
                 cds::opt::wait_strategy< cds::algo::flat_combining::wait_strategy::single_mutex_multi_condvar<> >
@@ -217,7 +217,7 @@ namespace {
 
     TEST_F( FCQueue, std_multi_mutex_multi_condvar_heavy_value )
     {
-    	typedef fc_test::HeavyValue<> ValueType;
+    	typedef fc_test::heavy_value<> ValueType;
         typedef cds::container::FCQueue<ValueType, std::queue< ValueType, std::deque<ValueType>>,
             cds::container::fcqueue::make_traits<
                 cds::opt::wait_strategy< cds::algo::flat_combining::wait_strategy::multi_mutex_multi_condvar<> >


### PR DESCRIPTION
Здравствуйте!

Всё таки доделал тесты для очереди основанной на Flat-combinig.

Но по решению есть пара вопросов:

1. Не лучше ли будет отдельно выделить тесты Flat-combinig?
2. Мне кажется неудачным решение на основе класса has_set_array_size, SFINAE и if-этапа компиляции, просто для того, чтоб разделить old_value и heavy_value в тестах, может лучше сделать это как-то иначе?