### PR TITLE
fixed add_custom_target() in intrusice-set and set

### DIFF
--- a/test/unit/intrusive-set/CMakeLists.txt
+++ b/test/unit/intrusive-set/CMakeLists.txt
@@ -130,7 +130,7 @@ add_custom_target( unit-iset
         ${UNIT_ISET_MICHAEL}
         ${UNIT_ISET_MICHAEL_ITERABLE}
         ${UNIT_ISET_MICHAEL_LAZY}
-        ${UNIT_ISET_SKIP_LIST}
+        ${UNIT_ISET_SKIP}
         ${UNIT_ISET_SPLIT_MICHAEL}
         ${UNIT_ISET_SPLIT_ITERABLE}
         ${UNIT_ISET_SPLIT_LAZY}

--- a/test/unit/set/CMakeLists.txt
+++ b/test/unit/set/CMakeLists.txt
@@ -127,7 +127,7 @@ add_custom_target( unit-set
         ${UNIT_SET_MICHAEL}
         ${UNIT_SET_MICHAEL_ITERABLE}
         ${UNIT_SET_MICHAEL_LAZY}
-        ${UNIT_SET_SKIP_LIST}
+        ${UNIT_SET_SKIP}
         ${UNIT_SET_SPLIT_MICHAEL}
         ${UNIT_SET_SPLIT_ITERABLE}
         ${UNIT_SET_SPLIT_LAZY}


### PR DESCRIPTION
два таргета в CMakeLists.txt были названы неправильно в add_custom_target(), по этому два теста не собиралось при сборке unit-iset или unit-set


