### PR TITLE
Add conan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: cpp
 
 install: 
-  - chmod +x ./CI/travis-ci/install.sh
-  - ./CI/travis-ci/install.sh
+  - chmod +x ./build/CI/travis-ci/install.sh
+  - ./build/CI/travis-ci/install.sh
 
 script:
-  - chmod +x ./CI/travis-ci/run.sh
-  - ./CI/travis-ci/run.sh
+  - chmod +x ./build/CI/travis-ci/run.sh
+  - ./build/CI/travis-ci/run.sh
 
 env:
 ##   BUILD_TYPE=Release CXX_COMPILER=g++-6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,12 @@
-dist: trusty
 language: cpp
 
-dist: trusty
-before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -y libgtest-dev
-  - sudo wget https://github.com/google/googletest/archive/release-1.7.0.tar.gz
-  - sudo tar xf release-1.7.0.tar.gz
-  - cd googletest-release-1.7.0
-  - sudo cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_C_COMPILER=$C_COMPILER -DCMAKE_CXX_COMPILER=$CXX_COMPILER .
-  - sudo make
-  - sudo cp -a include/gtest /usr/include
-  - sudo cp -a libgtest_main.so libgtest.so /usr/lib/
-  - cd "${TRAVIS_BUILD_DIR}"
+install: 
+  - chmod +x ./CI/travis-ci/install.sh
+  - ./CI/travis-ci/install.sh
 
 script:
-  - mkdir build-test && cd build-test
-  - cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=$C_COMPILER -DCMAKE_CXX_COMPILER=$CXX_COMPILER -DCMAKE_EXE_LINKER_FLAGS=$LINKER_FLAGS -DWITH_TESTS=ON ..
-  - cmake --build . -- -j$(nproc --all) $TARGET
-  - ctest -R $TARGET
+  - chmod +x ./CI/travis-ci/run.sh
+  - ./CI/travis-ci/run.sh
 
 env:
 ##   BUILD_TYPE=Release CXX_COMPILER=g++-6
@@ -100,7 +88,6 @@ addons:
       - ubuntu-toolchain-r-test
       - llvm-toolchain-trusty-5.0
     packages:
-      - libboost-all-dev
       - clang-5.0
       - g++-6
 

--- a/build/CI/travis-ci/install.sh
+++ b/build/CI/travis-ci/install.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    brew update || brew update
+    brew outdated pyenv || brew upgrade pyenv
+    brew install pyenv-virtualenv
+    brew install cmake || true
+
+    if which pyenv > /dev/null; then
+        eval "$(pyenv init -)"
+    fi
+
+    pyenv install 2.7.10
+    pyenv virtualenv 2.7.10 conan
+    pyenv rehash
+    pyenv activate conan
+    
+    pip install conan --upgrade
+    pip install conan_package_tools
+
+    conan user
+    exit 0
+fi
+
+pip install --user conan --upgrade
+pip install --user conan_package_tools
+
+conan user

--- a/build/CI/travis-ci/run.sh
+++ b/build/CI/travis-ci/run.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+set -x
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+    if which pyenv > /dev/null; then
+        eval "$(pyenv init -)"
+    fi
+    pyenv activate conan
+fi
+
+export CXX=$CXX_COMPILER
+export CC=$C_COMPILER
+mkdir build-test && cd build-test
+conan install --build=missing -s build_type=$BUILD_TYPE ..
+cmake -DCMAKE_PREFIX_PATH="$TRAVIS_BUILD_DIR/build-test/deps" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER=$C_COMPILER -DCMAKE_CXX_COMPILER=$CXX_COMPILER -DCMAKE_EXE_LINKER_FLAGS=$LINKER_FLAGS -DWITH_TESTS=ON ..
+cmake --build . -- -j2 $TARGET
+
+if [[ "$(uname -s)" == 'Darwin' ]]; then
+	export DYLD_LIBRARY_PATH=$TRAVIS_BUILD_DIR/build-test/deps/lib
+fi
+ctest -VV -R $TARGET

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,12 @@
+[requires]
+gtest/1.7.0@lasote/stable
+Boost/1.60.0@lasote/stable
+
+[options]
+Boost:shared=True
+
+# We copy the builded files in order to refer to them when calling cmake.
+# cmake -DCMAKE_PREFIX_PATH="build_dir/deps"
+[imports]
+include, * -> ./deps/include # Copies files
+lib, * -> ./deps/lib # Copies files

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -4,9 +4,37 @@ Boost/1.60.0@lasote/stable
 
 [options]
 Boost:shared=True
+Boost:without_atomic=False
+Boost:without_system=False
+Boost:without_thread=False
+Boost:without_chrono=True
+Boost:without_container=True
+Boost:without_context=True
+Boost:without_coroutine=True
+Boost:without_coroutine2=True
+Boost:without_date_time=True
+Boost:without_exception=True
+Boost:without_filesystem=True
+Boost:without_graph=True
+Boost:without_graph_parallel=True
+Boost:without_iostreams=True
+Boost:without_locale=True
+Boost:without_log=True
+Boost:without_math=True
+Boost:without_mpi=True
+Boost:without_program_options=True
+Boost:without_random=True
+Boost:without_regex=True
+Boost:without_serialization=True
+Boost:without_signals=True
+Boost:without_test=True
+Boost:without_timer=True
+Boost:without_type_erasure=True
+Boost:without_wave=True
 
 # We copy the builded files in order to refer to them when calling cmake.
 # cmake -DCMAKE_PREFIX_PATH="build_dir/deps"
 [imports]
 include, * -> ./deps/include # Copies files
 lib, * -> ./deps/lib # Copies files
+


### PR DESCRIPTION
Добавил поддержку [conan](https://www.conan.io/). Также обновил в связи с этим скрипты travis-ci.
Наличие conan немного упрощает утановку googletest во время job travis'a.
Также это облегчит запуск job на образах osx.
Сейчас с запуском на osx осталась последняя проблема
https://travis-ci.org/mgalimullin/libcds/jobs/287012792
```
6: [ RUN ] RCU_SHB/LazyKVList/0.stat

6: unknown file: Failure

6: C++ exception with description "random_device failed to open /dev/urandom: Too many open files" thrown in the test body.

6: [ FAILED ] RCU_SHB/LazyKVList/0.stat, where TypeParam = cds::urcu::signal_buffered<cds::container::VyukovMPMCCycleQueue<cds::urcu::epoch_retired_ptr, cds::container::vyukov_queue::traits>, std::__1::mutex, cds::backoff::exponential<cds::backoff::exponential_const_traits> > (0 ms)

6: [ RUN ] RCU_SHB/LazyKVList/0.wrapped_stat

6: unknown file: Failure

6: C++ exception with description "random_device failed to open /dev/urandom: Too many open files" thrown in the test body.

6: [ FAILED ] RCU_SHB/LazyKVList/0.wrapped_stat, where TypeParam = cds::urcu::signal_buffered<cds::container::VyukovMPMCCycleQueue<cds::urcu::epoch_retired_ptr, cds::container::vyukov_queue::traits>, std::__1::mutex, cds::backoff::exponential<cds::backoff::exponential_const_traits> > (0 ms)
```