### PR TITLE
changed clang version in travis-script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,51 +44,51 @@ env:
   - TARGET=unit-stack BUILD_TYPE=Debug C_COMPILER=gcc-6 CXX_COMPILER=g++-6
   - TARGET=unit-tree BUILD_TYPE=Debug C_COMPILER=gcc-6 CXX_COMPILER=g++-6
 
-##   BUILD_TYPE=Release CXX_COMPILER=clang-5.0
-  - TARGET=unit-deque BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-ilist BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-list BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-misc BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 LINKER_FLAGS=-latomic
-  - TARGET=unit-pqueue BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-queue BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-set-feldman BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-set-michael-michael BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-set-michael-iterable BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-set-michael-lazy BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-set-skip BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-set-split-iterable BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-set-split-michael BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-set-split-lazy BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-striped-set BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-stack BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
+##   BUILD_TYPE=Release CXX_COMPILER=clang-4.0
+  - TARGET=unit-deque BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-ilist BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-list BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-misc BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0 LINKER_FLAGS=-latomic
+  - TARGET=unit-pqueue BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-queue BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-set-feldman BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-set-michael-michael BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-set-michael-iterable BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-set-michael-lazy BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-set-skip BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-set-split-iterable BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-set-split-michael BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-set-split-lazy BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-striped-set BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-stack BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
 # FIXME: building too long. Travis-ci will stop building.
-#  - BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 TARGET=unit-map
-#  - BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 TARGET=unit-iset
-#  - BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 TARGET=unit-tree
+#  - BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0 TARGET=unit-map
+#  - BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0 TARGET=unit-iset
+#  - BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0 TARGET=unit-tree
 
 
-##   BUILD_TYPE=Debug CXX_COMPILER=clang-5.0
-  - TARGET=unit-deque BUILD_TYPE=Debug C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-ilist BUILD_TYPE=Debug C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-list BUILD_TYPE=Debug C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-map BUILD_TYPE=Debug C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-misc BUILD_TYPE=Debug C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 LINKER_FLAGS=-latomic
-  - TARGET=unit-pqueue BUILD_TYPE=Debug C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-queue BUILD_TYPE=Debug C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-iset BUILD_TYPE=Debug C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-set BUILD_TYPE=Debug C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-striped-set BUILD_TYPE=Debug C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-stack BUILD_TYPE=Debug C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-tree BUILD_TYPE=Debug C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
+##   BUILD_TYPE=Debug CXX_COMPILER=clang-4.0
+  - TARGET=unit-deque BUILD_TYPE=Debug C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-ilist BUILD_TYPE=Debug C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-list BUILD_TYPE=Debug C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-map BUILD_TYPE=Debug C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-misc BUILD_TYPE=Debug C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0 LINKER_FLAGS=-latomic
+  - TARGET=unit-pqueue BUILD_TYPE=Debug C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-queue BUILD_TYPE=Debug C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-iset BUILD_TYPE=Debug C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-set BUILD_TYPE=Debug C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-striped-set BUILD_TYPE=Debug C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-stack BUILD_TYPE=Debug C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-tree BUILD_TYPE=Debug C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
 
 
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-trusty-5.0
+      - llvm-toolchain-trusty-4.0
     packages:
-      - clang-5.0
+      - clang-4.0
       - g++-6
 
 #matrix:


### PR DESCRIPTION
Сменил версию clang на 4, conan к сожалению не поддерживает более новые версии.
Не очень понятно почему, он всё равно умеет строить библиотеки. 