### PR TITLE
Added osx to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,17 +91,92 @@ addons:
       - clang-4.0
       - g++-6
 
-#matrix:
-#  include:
-#    - os: osx
-#      osx_image: xcode8
-#      env: BUILD_TYPE=Debug
-#    - os: osx
-#      osx_image: xcode8.2
-#      env: BUILD_TYPE=Debug
-#    - os: osx
-#      osx_image: xcode8
-#      env: BUILD_TYPE=Release
-#    - os: osx
-#      osx_image: xcode8.2
-#      env: BUILD_TYPE=Release
+osx: &osx
+   os: osx
+   osx_image: xcode8.3
+
+matrix:
+  include:
+# RELEASE
+    - <<: *osx
+      env: BUILD_TYPE=Release TARGET=unit-deque C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Release TARGET=unit-ilist C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Release TARGET=unit-list C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Release TARGET=unit-map C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Release TARGET=unit-misc C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Release TARGET=unit-pqueue C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Release TARGET=unit-queue C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Release TARGET=unit-iset C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Release TARGET=unit-iset-feldman C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Release TARGET=unit-iset-michael-michael C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Release TARGET=unit-iset-michael-lazy C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Release TARGET=unit-iset-michael-iterable C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Release TARGET=unit-iset-skip C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Release TARGET=unit-iset-split-michael C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Release TARGET=unit-iset-split-lazy C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Release TARGET=unit-iset-split-iterable C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Release TARGET=unit-set C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Release TARGET=unit-striped-set C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Release TARGET=unit-stack C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Release TARGET=unit-tree C_COMPILER=clang CXX_COMPILER=clang++
+# DEBUG
+    - <<: *osx
+      env: BUILD_TYPE=Debug TARGET=unit-deque C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Debug TARGET=unit-ilist C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Debug TARGET=unit-list C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Debug TARGET=unit-map C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Debug TARGET=unit-misc C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Debug TARGET=unit-pqueue C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Debug TARGET=unit-queue C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Debug TARGET=unit-iset C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Debug TARGET=unit-iset-feldman C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Debug TARGET=unit-iset-michael-michael C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Debug TARGET=unit-iset-michael-lazy C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Debug TARGET=unit-iset-michael-iterable C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Debug TARGET=unit-iset-skip C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Debug TARGET=unit-iset-split-michael C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Debug TARGET=unit-iset-split-lazy C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Debug TARGET=unit-iset-split-iterable C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Debug TARGET=unit-set C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Debug TARGET=unit-striped-set C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Debug TARGET=unit-stack C_COMPILER=clang CXX_COMPILER=clang++
+    - <<: *osx
+      env: BUILD_TYPE=Debug TARGET=unit-tree C_COMPILER=clang CXX_COMPILER=clang++
+      

--- a/.travis.yml
+++ b/.travis.yml
@@ -105,8 +105,6 @@ matrix:
     - <<: *osx
       env: BUILD_TYPE=Release TARGET=unit-list C_COMPILER=clang CXX_COMPILER=clang++
     - <<: *osx
-      env: BUILD_TYPE=Release TARGET=unit-map C_COMPILER=clang CXX_COMPILER=clang++
-    - <<: *osx
       env: BUILD_TYPE=Release TARGET=unit-misc C_COMPILER=clang CXX_COMPILER=clang++
     - <<: *osx
       env: BUILD_TYPE=Release TARGET=unit-pqueue C_COMPILER=clang CXX_COMPILER=clang++
@@ -131,13 +129,17 @@ matrix:
     - <<: *osx
       env: BUILD_TYPE=Release TARGET=unit-iset-split-iterable C_COMPILER=clang CXX_COMPILER=clang++
     - <<: *osx
-      env: BUILD_TYPE=Release TARGET=unit-set C_COMPILER=clang CXX_COMPILER=clang++
-    - <<: *osx
       env: BUILD_TYPE=Release TARGET=unit-striped-set C_COMPILER=clang CXX_COMPILER=clang++
     - <<: *osx
       env: BUILD_TYPE=Release TARGET=unit-stack C_COMPILER=clang CXX_COMPILER=clang++
-    - <<: *osx
-      env: BUILD_TYPE=Release TARGET=unit-tree C_COMPILER=clang CXX_COMPILER=clang++
+# FIXME: building too long. Travis-ci will stop building.
+#    - <<: *osx
+#      env: BUILD_TYPE=Release TARGET=unit-map C_COMPILER=clang CXX_COMPILER=clang++
+#    - <<: *osx
+#      env: BUILD_TYPE=Release TARGET=unit-set C_COMPILER=clang CXX_COMPILER=clang++
+#    - <<: *osx
+#      env: BUILD_TYPE=Release TARGET=unit-tree C_COMPILER=clang CXX_COMPILER=clang++
+
 # DEBUG
     - <<: *osx
       env: BUILD_TYPE=Debug TARGET=unit-deque C_COMPILER=clang CXX_COMPILER=clang++

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,51 +44,51 @@ env:
   - TARGET=unit-stack BUILD_TYPE=Debug C_COMPILER=gcc-6 CXX_COMPILER=g++-6
   - TARGET=unit-tree BUILD_TYPE=Debug C_COMPILER=gcc-6 CXX_COMPILER=g++-6
 
-##   BUILD_TYPE=Release CXX_COMPILER=clang-5.0
-  - TARGET=unit-deque BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-ilist BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-list BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-misc BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 LINKER_FLAGS=-latomic
-  - TARGET=unit-pqueue BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-queue BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-set-feldman BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-set-michael-michael BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-set-michael-iterable BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-set-michael-lazy BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-set-skip BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-set-split-iterable BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-set-split-michael BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-set-split-lazy BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-striped-set BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-stack BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
+##   BUILD_TYPE=Release CXX_COMPILER=clang-4.0
+  - TARGET=unit-deque BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-ilist BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-list BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-misc BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0 LINKER_FLAGS=-latomic
+  - TARGET=unit-pqueue BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-queue BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-set-feldman BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-set-michael-michael BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-set-michael-iterable BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-set-michael-lazy BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-set-skip BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-set-split-iterable BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-set-split-michael BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-set-split-lazy BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-striped-set BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-stack BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
 # FIXME: building too long. Travis-ci will stop building.
-#  - BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 TARGET=unit-map
-#  - BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 TARGET=unit-iset
-#  - BUILD_TYPE=Release C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 TARGET=unit-tree
+#  - BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0 TARGET=unit-map
+#  - BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0 TARGET=unit-iset
+#  - BUILD_TYPE=Release C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0 TARGET=unit-tree
 
 
-##   BUILD_TYPE=Debug CXX_COMPILER=clang-5.0
-  - TARGET=unit-deque BUILD_TYPE=Debug C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-ilist BUILD_TYPE=Debug C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-list BUILD_TYPE=Debug C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-map BUILD_TYPE=Debug C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-misc BUILD_TYPE=Debug C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0 LINKER_FLAGS=-latomic
-  - TARGET=unit-pqueue BUILD_TYPE=Debug C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-queue BUILD_TYPE=Debug C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-iset BUILD_TYPE=Debug C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-set BUILD_TYPE=Debug C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-striped-set BUILD_TYPE=Debug C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-stack BUILD_TYPE=Debug C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
-  - TARGET=unit-tree BUILD_TYPE=Debug C_COMPILER=clang-5.0 CXX_COMPILER=clang++-5.0
+##   BUILD_TYPE=Debug CXX_COMPILER=clang-4.0
+  - TARGET=unit-deque BUILD_TYPE=Debug C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-ilist BUILD_TYPE=Debug C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-list BUILD_TYPE=Debug C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-map BUILD_TYPE=Debug C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-misc BUILD_TYPE=Debug C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0 LINKER_FLAGS=-latomic
+  - TARGET=unit-pqueue BUILD_TYPE=Debug C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-queue BUILD_TYPE=Debug C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-iset BUILD_TYPE=Debug C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-set BUILD_TYPE=Debug C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-striped-set BUILD_TYPE=Debug C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-stack BUILD_TYPE=Debug C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
+  - TARGET=unit-tree BUILD_TYPE=Debug C_COMPILER=clang-4.0 CXX_COMPILER=clang++-4.0
 
 
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
-      - llvm-toolchain-trusty-5.0
+      - llvm-toolchain-trusty-4.0
     packages:
-      - clang-5.0
+      - clang-4.0
       - g++-6
 
 #matrix:

--- a/test/include/cds_test/fixture.h
+++ b/test/include/cds_test/fixture.h
@@ -43,7 +43,7 @@ namespace cds_test {
         template <typename RandomIt>
         static void shuffle( RandomIt first, RandomIt last )
         {
-        	std::shuffle( first, last, std::mt19937( std::random_device()() ) );
+            std::shuffle( first, last, std::mt19937( std::random_device()() ) );
         }
 
         static inline unsigned int rand( unsigned int nMax )

--- a/test/include/cds_test/fixture.h
+++ b/test/include/cds_test/fixture.h
@@ -43,10 +43,7 @@ namespace cds_test {
         template <typename RandomIt>
         static void shuffle( RandomIt first, RandomIt last )
         {
-            static std::random_device random_dev;
-            static std::mt19937       random_gen( random_dev());
-
-            std::shuffle( first, last, random_gen );
+        	std::shuffle( first, last, std::mt19937( std::random_device()() ) );
         }
 
         static inline unsigned int rand( unsigned int nMax )


### PR DESCRIPTION
Добавил в travis-ci сборки в виртуальных машинах OSX.
Изменил в test/include/cds_test/fixture.h как Вы предлагали, это помогло с ошибками в тестах.

Очереди на вм с OSX очень долгие, что очень удленяет сборку. Можно будет, позже, премешать сборки linux и osx, таким образом, чтобы пока нет свободных osx-машин сбоирались linux сборки.