### PR TITLE
updated version gtest in conanfile 1.7.0 -> 1.8.0

### DIFF
--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,5 +1,5 @@
 [requires]
-gtest/1.7.0@lasote/stable
+gtest/1.8.0@lasote/stable
 Boost/1.60.0@lasote/stable
 
 [options]


### PR DESCRIPTION
Что-то с конаном в трависе сломалось. К сожалению не разбирался что, но переход на более новую версию gtest решило проблему https://travis-ci.org/mgalimullin/libcds/builds/319212222 