### PR TITLE
fixed macro

### DIFF
--- a/cds/details/defs.h
+++ b/cds/details/defs.h
@@ -326,12 +326,12 @@ namespace cds {}
 #   define CDS_VERIFY( _expr )       assert( _expr )
 #   define CDS_VERIFY_FALSE( _expr ) assert( !( _expr ))
 #   define CDS_DEBUG_ONLY( _expr )        _expr
-#   define CDS_VERIFY_EQ( expr, val )   assert( expr == val )
+#   define CDS_VERIFY_EQ( _expr, val )   assert( (_expr) == (val) )
 #else
 #   define CDS_VERIFY( _expr )    _expr
 #   define CDS_VERIFY_FALSE( _expr ) _expr
 #   define CDS_DEBUG_ONLY( _expr )
-#   define CDS_VERIFY_EQ( expr, val )   expr
+#   define CDS_VERIFY_EQ( _expr, val )   _expr
 #endif
 
 #ifdef CDS_STRICT


### PR DESCRIPTION
Макрос CDS_VERIFY_EQ потенциально может выдавать неверные результаты. 
Например, при вызове CDS_VERIFY_EQ(3, 4|1)