### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,6 +50,18 @@ switches DCAS support on. You may manually disable DCAS support with the followi
 in GCC/clang (for MS VC++ compiler DCAS is not supported):
   - `-DCDS_DISABLE_128BIT_ATOMIC` - for 64bit build
   - `-DCDS_DISABLE_64BIT_ATOMIC` - for 32bit build
+  
+**Building libcds -use vcpkg
+
+You can download and install libcds using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+   
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    vcpkg install libcds
+    
+The libcds port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 **All your projects AND libcds MUST be compiled with the same flags - either with DCAS support or without it.**
    


### PR DESCRIPTION
`libcds `is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `libcds `and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build `libcds`, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/libcds/portfile.cmake). We try to keep the library maintained as close as possible to the original library.