### PR TITLE
make m_nAttachCount atomic

### DIFF
--- a/cds/threading/details/_common.h
+++ b/cds/threading/details/_common.h
@@ -118,7 +118,7 @@ namespace cds {
             size_t  m_nFakeProcessorNumber  ;   ///< fake "current processor" number
 
             //@cond
-            size_t  m_nAttachCount;
+            std::atomic<size_t>  m_nAttachCount;
             //@endcond
 
             /// Per-thread elimination record


### PR DESCRIPTION
m_nAttachCount might be concurrently accessed by multi-threads when they try to initialize thread data. If not being atomic protected, non-main thread might get the chance to call `detach_thread` here https://github.com/khizmax/libcds/blob/777f7a5aae463085ebf987af232ff976e97ca529/src/thread_data.cpp#L42 and eventually failed at here https://github.com/khizmax/libcds/blob/777f7a5aae463085ebf987af232ff976e97ca529/src/hp.cpp#L474