### PR TITLE
Generic Hazard Pointers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,7 @@ set(HEADERS_COMPONENT devel)
 
 set(SOURCES src/init.cpp
             src/hp.cpp
+            src/hp_thread_local.cpp
             src/dhp.cpp
             src/urcu_gp.cpp
             src/urcu_sh.cpp

--- a/cds/gc/dhp.h
+++ b/cds/gc/dhp.h
@@ -310,7 +310,7 @@ namespace cds { namespace gc {
                     }
 
                     // no free block
-                    // smr::scan() extend retired_array if needed
+                    // basic_smr::scan() extend retired_array if needed
                     return false;
                 }
 
@@ -325,7 +325,7 @@ namespace cds { namespace gc {
                 return ret;
             }
 
-        private: // called by smr
+        private: // called by basic_smr
             void init()
             {
                 if ( list_head_ == nullptr ) {
@@ -479,7 +479,7 @@ namespace cds { namespace gc {
             struct thread_record;
 
         public:
-            /// Returns the instance of Hazard Pointer \ref smr
+            /// Returns the instance of Hazard Pointer \ref basic_smr
             static smr& instance()
             {
 #       ifdef CDS_DISABLE_SMR_EXCEPTION
@@ -517,7 +517,7 @@ namespace cds { namespace gc {
                 construct( nInitialHazardPtrCount );
             }
 
-            /// Destroys global instance of \ref smr
+            /// Destroys global instance of \ref basic_smr
             /**
                 The parameter \p bDetachAll should be used carefully: if its value is \p true,
                 then the object destroyed automatically detaches all attached threads. This feature

--- a/cds/gc/hp.h
+++ b/cds/gc/hp.h
@@ -307,7 +307,7 @@ namespace cds { namespace gc {
                 }
             };
 
-            static stat const& postmortem_statistics();
+            stat const& postmortem_statistics();
 
             //@cond
             /// Per-thread data
@@ -631,6 +631,9 @@ namespace cds { namespace gc {
         typedef details::generic_smr<details::DefaultTLSManager> smr;
         typedef smr GarbageCollector;
         //@endcond
+
+        template<typename TLSManager>
+        using custom_smr = details::generic_smr<TLSManager>;
     } // namespace cds::gc::hp
 
     namespace details {
@@ -1514,9 +1517,13 @@ namespace cds { namespace gc {
     };
     } // namespace cds::gc::details
 
+    //@cond
     // for backward compatibility
     typedef details::generic_HP<hp::details::DefaultTLSManager> HP;
-    typedef hp::details::basic_smr smr;
+    //@endcond
+
+    template<typename TLSManager>
+    using custom_HP = details::generic_HP<TLSManager>;
 }} // namespace cds::gc
 
 #endif // #ifndef CDSLIB_GC_HP_SMR_H

--- a/cds/gc/hp.h
+++ b/cds/gc/hp.h
@@ -62,566 +62,533 @@ namespace cds {
 namespace cds { namespace gc {
     /// Hazard pointer implementation details
     namespace hp {
-        using namespace cds::gc::hp::common;
+        namespace details {
+            using namespace cds::gc::hp::common;
 
-        /// Exception "Not enough Hazard Pointer"
-        class not_enough_hazard_ptr: public std::length_error
-        {
-        //@cond
-        public:
-            not_enough_hazard_ptr()
-                : std::length_error( "Not enough Hazard Pointer" )
-            {}
-        //@endcond
-        };
+            /// Exception "Not enough Hazard Pointer"
+            class not_enough_hazard_ptr : public std::length_error {
+                //@cond
+            public:
+                not_enough_hazard_ptr()
+                        : std::length_error("Not enough Hazard Pointer") {}
+                //@endcond
+            };
 
-        /// Exception "Hazard Pointer SMR is not initialized"
-        class not_initialized: public std::runtime_error
-        {
-        //@cond
-        public:
-            not_initialized()
-                : std::runtime_error( "Global Hazard Pointer SMR object is not initialized" )
-            {}
-        //@endcond
-        };
+            /// Exception "Hazard Pointer SMR is not initialized"
+            class not_initialized : public std::runtime_error {
+                //@cond
+            public:
+                not_initialized()
+                        : std::runtime_error("Global Hazard Pointer SMR object is not initialized") {}
+                //@endcond
+            };
 
-        //@cond
-        /// Per-thread hazard pointer storage
-        class thread_hp_storage {
-        public:
-            thread_hp_storage( guard* arr, size_t nSize ) noexcept
-                : free_head_( arr )
-                , array_( arr )
-                , capacity_( nSize )
+            //@cond
+            /// Per-thread hazard pointer storage
+            class thread_hp_storage {
+            public:
+                thread_hp_storage(guard *arr, size_t nSize) noexcept
+                        : free_head_(arr), array_(arr), capacity_(nSize)
 #       ifdef CDS_ENABLE_HPSTAT
                 , alloc_guard_count_(0)
                 , free_guard_count_(0)
 #       endif
-            {
-                // Initialize guards
-                new( arr ) guard[nSize];
+                {
+                    // Initialize guards
+                    new(arr) guard[nSize];
 
-                for ( guard* pEnd = arr + nSize - 1; arr < pEnd; ++arr )
-                    arr->next_ = arr + 1;
-                arr->next_ = nullptr;
-            }
-
-            thread_hp_storage() = delete;
-            thread_hp_storage( thread_hp_storage const& ) = delete;
-            thread_hp_storage( thread_hp_storage&& ) = delete;
-
-            size_t capacity() const noexcept
-            {
-                return capacity_;
-            }
-
-            bool full() const noexcept
-            {
-                return free_head_ == nullptr;
-            }
-
-            guard* alloc()
-            {
-#       ifdef CDS_DISABLE_SMR_EXCEPTION
-                assert( !full());
-#       else
-                if ( full())
-                    CDS_THROW_EXCEPTION( not_enough_hazard_ptr());
-#       endif
-                guard* g = free_head_;
-                free_head_ = g->next_;
-                CDS_HPSTAT( ++alloc_guard_count_ );
-                return g;
-            }
-
-            void free( guard* g ) noexcept
-            {
-                assert( g >= array_ && g < array_ + capacity());
-
-                if ( g ) {
-                    g->clear();
-                    g->next_ = free_head_;
-                    free_head_ = g;
-                    CDS_HPSTAT( ++free_guard_count_ );
-                }
-            }
-
-            template< size_t Capacity>
-            size_t alloc( guard_array<Capacity>& arr )
-            {
-                size_t i;
-                guard* g = free_head_;
-                for ( i = 0; i < Capacity && g; ++i ) {
-                    arr.reset( i, g );
-                    g = g->next_;
+                    for (guard *pEnd = arr + nSize - 1; arr < pEnd; ++arr)
+                        arr->next_ = arr + 1;
+                    arr->next_ = nullptr;
                 }
 
-#       ifdef CDS_DISABLE_SMR_EXCEPTION
-                assert( i == Capacity );
-#       else
-                if ( i != Capacity )
-                    CDS_THROW_EXCEPTION( not_enough_hazard_ptr());
-#       endif
-                free_head_ = g;
-                CDS_HPSTAT( alloc_guard_count_ += Capacity );
-                return i;
-            }
+                thread_hp_storage() = delete;
 
-            template <size_t Capacity>
-            void free( guard_array<Capacity>& arr ) noexcept
-            {
-                guard* gList = free_head_;
-                for ( size_t i = 0; i < Capacity; ++i ) {
-                    guard* g = arr[i];
-                    if ( g ) {
+                thread_hp_storage(thread_hp_storage const &) = delete;
+
+                thread_hp_storage(thread_hp_storage &&) = delete;
+
+                size_t capacity() const noexcept {
+                    return capacity_;
+                }
+
+                bool full() const noexcept {
+                    return free_head_ == nullptr;
+                }
+
+                guard *alloc() {
+#       ifdef CDS_DISABLE_SMR_EXCEPTION
+                    assert( !full());
+#       else
+                    if (full())
+                        CDS_THROW_EXCEPTION(not_enough_hazard_ptr());
+#       endif
+                    guard *g = free_head_;
+                    free_head_ = g->next_;
+                    CDS_HPSTAT(++alloc_guard_count_);
+                    return g;
+                }
+
+                void free(guard *g) noexcept {
+                    assert(g >= array_ && g < array_ + capacity());
+
+                    if (g) {
                         g->clear();
-                        g->next_ = gList;
-                        gList = g;
-                        CDS_HPSTAT( ++free_guard_count_ );
+                        g->next_ = free_head_;
+                        free_head_ = g;
+                        CDS_HPSTAT(++free_guard_count_);
                     }
                 }
-                free_head_ = gList;
-            }
 
-            // cppcheck-suppress functionConst
-            void clear()
-            {
-                for ( guard* cur = array_, *last = array_ + capacity(); cur < last; ++cur )
-                    cur->clear();
-            }
+                template<size_t Capacity>
+                size_t alloc(guard_array<Capacity> &arr) {
+                    size_t i;
+                    guard *g = free_head_;
+                    for (i = 0; i < Capacity && g; ++i) {
+                        arr.reset(i, g);
+                        g = g->next_;
+                    }
 
-            guard& operator[]( size_t idx )
-            {
-                assert( idx < capacity());
-
-                return array_[idx];
-            }
-
-            static size_t calc_array_size( size_t capacity )
-            {
-                return sizeof( guard ) * capacity;
-            }
-
-            guard* begin() const
-            {
-                return array_;
-            }
-
-            guard* end() const
-            {
-                return &array_[capacity_];
-            }
-
-        private:
-            guard*          free_head_; ///< Head of free guard list
-            guard* const    array_;     ///< HP array
-            size_t const    capacity_;  ///< HP array capacity
-#       ifdef CDS_ENABLE_HPSTAT
-        public:
-            size_t          alloc_guard_count_;
-            size_t          free_guard_count_;
+#       ifdef CDS_DISABLE_SMR_EXCEPTION
+                    assert( i == Capacity );
+#       else
+                    if (i != Capacity)
+                        CDS_THROW_EXCEPTION(not_enough_hazard_ptr());
 #       endif
-        };
-        //@endcond
+                    free_head_ = g;
+                    CDS_HPSTAT(alloc_guard_count_ += Capacity);
+                    return i;
+                }
 
-        //@cond
-        /// Per-thread retired array
-        class retired_array
-        {
-        public:
-            retired_array( retired_ptr* arr, size_t capacity ) noexcept
-                : current_( arr )
-                , last_( arr + capacity )
-                , retired_( arr )
+                template<size_t Capacity>
+                void free(guard_array<Capacity> &arr) noexcept {
+                    guard *gList = free_head_;
+                    for (size_t i = 0; i < Capacity; ++i) {
+                        guard *g = arr[i];
+                        if (g) {
+                            g->clear();
+                            g->next_ = gList;
+                            gList = g;
+                            CDS_HPSTAT(++free_guard_count_);
+                        }
+                    }
+                    free_head_ = gList;
+                }
+
+                // cppcheck-suppress functionConst
+                void clear() {
+                    for (guard *cur = array_, *last = array_ + capacity(); cur < last; ++cur)
+                        cur->clear();
+                }
+
+                guard &operator[](size_t idx) {
+                    assert(idx < capacity());
+
+                    return array_[idx];
+                }
+
+                static size_t calc_array_size(size_t capacity) {
+                    return sizeof(guard) * capacity;
+                }
+
+                guard *begin() const {
+                    return array_;
+                }
+
+                guard *end() const {
+                    return &array_[capacity_];
+                }
+
+            private:
+                guard *free_head_; ///< Head of free guard list
+                guard *const array_;     ///< HP array
+                size_t const capacity_;  ///< HP array capacity
+#       ifdef CDS_ENABLE_HPSTAT
+                public:
+                    size_t          alloc_guard_count_;
+                    size_t          free_guard_count_;
+#       endif
+            };
+            //@endcond
+
+            //@cond
+            /// Per-thread retired array
+            class retired_array {
+            public:
+                retired_array(retired_ptr *arr, size_t capacity) noexcept
+                        : current_(arr), last_(arr + capacity), retired_(arr)
 #       ifdef CDS_ENABLE_HPSTAT
                 , retire_call_count_(0)
 #       endif
-            {}
+                {}
 
-            retired_array() = delete;
-            retired_array( retired_array const& ) = delete;
-            retired_array( retired_array&& ) = delete;
+                retired_array() = delete;
 
-            size_t capacity() const noexcept
-            {
-                return last_ - retired_;
-            }
+                retired_array(retired_array const &) = delete;
 
-            size_t size() const noexcept
-            {
-                return current_.load(atomics::memory_order_relaxed) - retired_;
-            }
+                retired_array(retired_array &&) = delete;
 
-            bool push( retired_ptr&& p ) noexcept
-            {
-                retired_ptr* cur = current_.load( atomics::memory_order_relaxed );
-                *cur = p;
-                CDS_HPSTAT( ++retire_call_count_ );
-                current_.store( cur + 1, atomics::memory_order_relaxed );
-                return cur + 1 < last_;
-            }
+                size_t capacity() const noexcept {
+                    return last_ - retired_;
+                }
 
-            retired_ptr* first() const noexcept
-            {
-                return retired_;
-            }
+                size_t size() const noexcept {
+                    return current_.load(atomics::memory_order_relaxed) - retired_;
+                }
 
-            retired_ptr* last() const noexcept
-            {
-                return current_.load( atomics::memory_order_relaxed );
-            }
+                bool push(retired_ptr &&p) noexcept {
+                    retired_ptr *cur = current_.load(atomics::memory_order_relaxed);
+                    *cur = p;
+                    CDS_HPSTAT(++retire_call_count_);
+                    current_.store(cur + 1, atomics::memory_order_relaxed);
+                    return cur + 1 < last_;
+                }
 
-            void reset( size_t nSize ) noexcept
-            {
-                current_.store( first() + nSize, atomics::memory_order_relaxed );
-            }
+                retired_ptr *first() const noexcept {
+                    return retired_;
+                }
 
-            void interthread_clear()
-            {
-                current_.exchange( first(), atomics::memory_order_acq_rel );
-            }
+                retired_ptr *last() const noexcept {
+                    return current_.load(atomics::memory_order_relaxed);
+                }
 
-            bool full() const noexcept
-            {
-                return current_.load( atomics::memory_order_relaxed ) == last_;
-            }
+                void reset(size_t nSize) noexcept {
+                    current_.store(first() + nSize, atomics::memory_order_relaxed);
+                }
 
-            static size_t calc_array_size( size_t capacity )
-            {
-                return sizeof( retired_ptr ) * capacity;
-            }
+                void interthread_clear() {
+                    current_.exchange(first(), atomics::memory_order_acq_rel);
+                }
 
-        private:
-            atomics::atomic<retired_ptr*> current_;
-            retired_ptr* const            last_;
-            retired_ptr* const            retired_;
+                bool full() const noexcept {
+                    return current_.load(atomics::memory_order_relaxed) == last_;
+                }
+
+                static size_t calc_array_size(size_t capacity) {
+                    return sizeof(retired_ptr) * capacity;
+                }
+
+            private:
+                atomics::atomic<retired_ptr *> current_;
+                retired_ptr *const last_;
+                retired_ptr *const retired_;
 #       ifdef CDS_ENABLE_HPSTAT
-        public:
-            size_t  retire_call_count_;
+                public:
+                    size_t  retire_call_count_;
 #       endif
-        };
-        //@endcond
+            };
+            //@endcond
 
-        /// Internal statistics
-        struct stat {
-            size_t  guard_allocated;    ///< Count of allocated HP guards
-            size_t  guard_freed;        ///< Count of freed HP guards
-            size_t  retired_count;      ///< Count of retired pointers
-            size_t  free_count;         ///< Count of free pointers
-            size_t  scan_count;         ///< Count of \p scan() call
-            size_t  help_scan_count;    ///< Count of \p help_scan() call
+            /// Internal statistics
+            struct stat {
+                size_t guard_allocated;    ///< Count of allocated HP guards
+                size_t guard_freed;        ///< Count of freed HP guards
+                size_t retired_count;      ///< Count of retired pointers
+                size_t free_count;         ///< Count of free pointers
+                size_t scan_count;         ///< Count of \p scan() call
+                size_t help_scan_count;    ///< Count of \p help_scan() call
 
-            size_t  thread_rec_count;   ///< Count of thread records
+                size_t thread_rec_count;   ///< Count of thread records
 
-            /// Default ctor
-            stat()
-            {
-                clear();
-            }
+                /// Default ctor
+                stat() {
+                    clear();
+                }
 
-            /// Clears all counters
-            void clear()
-            {
-                guard_allocated =
+                /// Clears all counters
+                void clear() {
+                    guard_allocated =
                     guard_freed =
                     retired_count =
                     free_count =
                     scan_count =
                     help_scan_count =
                     thread_rec_count = 0;
-            }
-        };
+                }
+            };
 
-        //@cond
-        /// Per-thread data
-        struct thread_data {
-            thread_hp_storage   hazards_;   ///< Hazard pointers private to the thread
-            retired_array       retired_;   ///< Retired data private to the thread
+            //@cond
+            /// Per-thread data
+            struct thread_data {
+                thread_hp_storage hazards_;   ///< Hazard pointers private to the thread
+                retired_array retired_;   ///< Retired data private to the thread
 
-            char pad1_[cds::c_nCacheLineSize];
-            atomics::atomic<unsigned int> sync_; ///< dummy var to introduce synchronizes-with relationship between threads
-            char pad2_[cds::c_nCacheLineSize];
+                char pad1_[cds::c_nCacheLineSize];
+                atomics::atomic<unsigned int> sync_; ///< dummy var to introduce synchronizes-with relationship between threads
+                char pad2_[cds::c_nCacheLineSize];
 
 #       ifdef CDS_ENABLE_HPSTAT
-            // Internal statistics:
-            size_t              free_count_;
-            size_t              scan_count_;
-            size_t              help_scan_count_;
+                // Internal statistics:
+                size_t              free_count_;
+                size_t              scan_count_;
+                size_t              help_scan_count_;
 #       endif
 
-            // CppCheck warn: pad1_ and pad2_ is uninitialized in ctor
-            // cppcheck-suppress uninitMemberVar
-            thread_data( guard* guards, size_t guard_count, retired_ptr* retired_arr, size_t retired_capacity )
-                : hazards_( guards, guard_count )
-                , retired_( retired_arr, retired_capacity )
-                , sync_(0)
+                // CppCheck warn: pad1_ and pad2_ is uninitialized in ctor
+                // cppcheck-suppress uninitMemberVar
+                thread_data(guard *guards, size_t guard_count, retired_ptr *retired_arr, size_t retired_capacity)
+                        : hazards_(guards, guard_count), retired_(retired_arr, retired_capacity), sync_(0)
 #       ifdef CDS_ENABLE_HPSTAT
                 , free_count_(0)
                 , scan_count_(0)
                 , help_scan_count_(0)
 #       endif
-            {}
+                {}
 
-            thread_data() = delete;
-            thread_data( thread_data const& ) = delete;
-            thread_data( thread_data&& ) = delete;
+                thread_data() = delete;
 
-            void sync()
-            {
-                sync_.fetch_add( 1, atomics::memory_order_acq_rel );
-            }
-        };
-        //@endcond
+                thread_data(thread_data const &) = delete;
 
-        /// \p smr::scan() strategy
-        enum scan_type {
-            classic,    ///< classic scan as described in Michael's works (see smr::classic_scan())
-            inplace     ///< inplace scan without allocation (see smr::inplace_scan())
-        };
+                thread_data(thread_data &&) = delete;
 
-        //@cond
-        /// Hazard Pointer SMR (Safe Memory Reclamation)
-        class smr
-        {
-            struct thread_record;
-
-        public:
-            /// Returns the instance of Hazard Pointer \ref smr
-            static smr& instance()
-            {
-#       ifdef CDS_DISABLE_SMR_EXCEPTION
-                assert( instance_ != nullptr );
-#       else
-                if ( !instance_ )
-                    CDS_THROW_EXCEPTION( not_initialized());
-#       endif
-                return *instance_;
-            }
-
-            /// Creates Hazard Pointer SMR singleton
-            /**
-                Hazard Pointer SMR is a singleton. If HP instance is not initialized then the function creates the instance.
-                Otherwise it does nothing.
-
-                The Michael's HP reclamation schema depends of three parameters:
-                - \p nHazardPtrCount - HP pointer count per thread. Usually it is small number (2-4) depending from
-                    the data structure algorithms. By default, if \p nHazardPtrCount = 0,
-                    the function uses maximum of HP count for CDS library
-                - \p nMaxThreadCount - max count of thread with using HP GC in your application. Default is 100.
-                - \p nMaxRetiredPtrCount - capacity of array of retired pointers for each thread. Must be greater than
-                    <tt> nHazardPtrCount * nMaxThreadCount </tt>
-                    Default is <tt>2 * nHazardPtrCount * nMaxThreadCount</tt>
-            */
-            static CDS_EXPORT_API void construct(
-                size_t nHazardPtrCount = 0,     ///< Hazard pointer count per thread
-                size_t nMaxThreadCount = 0,     ///< Max count of simultaneous working thread in your application
-                size_t nMaxRetiredPtrCount = 0, ///< Capacity of the array of retired objects for the thread
-                scan_type nScanType = inplace   ///< Scan type (see \ref scan_type enum)
-            );
-
-            // for back-copatibility
-            static void Construct(
-                size_t nHazardPtrCount = 0,     ///< Hazard pointer count per thread
-                size_t nMaxThreadCount = 0,     ///< Max count of simultaneous working thread in your application
-                size_t nMaxRetiredPtrCount = 0, ///< Capacity of the array of retired objects for the thread
-                scan_type nScanType = inplace   ///< Scan type (see \ref scan_type enum)
-            )
-            {
-                construct( nHazardPtrCount, nMaxThreadCount, nMaxRetiredPtrCount, nScanType );
-            }
-
-            /// Destroys global instance of \ref smr
-            /**
-                The parameter \p bDetachAll should be used carefully: if its value is \p true,
-                then the object destroyed automatically detaches all attached threads. This feature
-                can be useful when you have no control over the thread termination, for example,
-                when \p libcds is injected into existing external thread.
-            */
-            static CDS_EXPORT_API void destruct(
-                bool bDetachAll = false     ///< Detach all threads
-            );
-
-            // for back-compatibility
-            static void Destruct(
-                bool bDetachAll = false     ///< Detach all threads
-            )
-            {
-                destruct( bDetachAll );
-            }
-
-            /// Checks if global SMR object is constructed and may be used
-            static bool isUsed() noexcept
-            {
-                return instance_ != nullptr;
-            }
-
-            /// Set memory management functions
-            /**
-                @note This function may be called <b>BEFORE</b> creating an instance
-                of Hazard Pointer SMR
-
-                SMR object allocates some memory for thread-specific data and for
-                creating SMR object.
-                By default, a standard \p new and \p delete operators are used for this.
-            */
-            static CDS_EXPORT_API void set_memory_allocator(
-                void* ( *alloc_func )( size_t size ),
-                void (*free_func )( void * p )
-            );
-
-            /// Returns max Hazard Pointer count per thread
-            size_t get_hazard_ptr_count() const noexcept
-            {
-                return hazard_ptr_count_;
-            }
-
-            /// Returns max thread count
-            size_t get_max_thread_count() const noexcept
-            {
-                return max_thread_count_;
-            }
-
-            /// Returns max size of retired objects array
-            size_t get_max_retired_ptr_count() const noexcept
-            {
-                return max_retired_ptr_count_;
-            }
-
-            /// Get current scan strategy
-            scan_type get_scan_type() const
-            {
-                return scan_type_;
-            }
-
-            /// Checks that required hazard pointer count \p nRequiredCount is less or equal then max hazard pointer count
-            /**
-                If <tt> nRequiredCount > get_hazard_ptr_count()</tt> then the exception \p not_enough_hazard_ptr is thrown
-            */
-            static void check_hazard_ptr_count( size_t nRequiredCount )
-            {
-                if ( instance().get_hazard_ptr_count() < nRequiredCount ) {
-#       ifdef CDS_DISABLE_SMR_EXCEPTION
-                    assert( false );    // not enough hazard ptr
-#       else
-                    CDS_THROW_EXCEPTION( not_enough_hazard_ptr());
-#       endif
+                void sync() {
+                    sync_.fetch_add(1, atomics::memory_order_acq_rel);
                 }
-            }
+            };
+            //@endcond
 
-            /// Returns thread-local data for the current thread
-            static CDS_EXPORT_API thread_data* tls();
+            /// \p smr::scan() strategy
+            enum scan_type {
+                classic,    ///< classic scan as described in Michael's works (see smr::classic_scan())
+                inplace     ///< inplace scan without allocation (see smr::inplace_scan())
+            };
 
-            static CDS_EXPORT_API void attach_thread();
-            static CDS_EXPORT_API void detach_thread();
+            //@cond
+            /// Hazard Pointer SMR (Safe Memory Reclamation)
+            class smr {
+                struct thread_record;
 
-            /// Get internal statistics
-            CDS_EXPORT_API void statistics( stat& st );
+            public:
+                /// Returns the instance of Hazard Pointer \ref smr
+                static smr &instance() {
+#       ifdef CDS_DISABLE_SMR_EXCEPTION
+                    assert( instance_ != nullptr );
+#       else
+                    if (!instance_)
+                        CDS_THROW_EXCEPTION(not_initialized());
+#       endif
+                    return *instance_;
+                }
 
-        public: // for internal use only
-            /// The main garbage collecting function
-            /**
-                This function is called internally when upper bound of thread's list of reclaimed pointers
-                is reached.
+                /// Creates Hazard Pointer SMR singleton
+                /**
+                    Hazard Pointer SMR is a singleton. If HP instance is not initialized then the function creates the instance.
+                    Otherwise it does nothing.
 
-                There are the following scan algorithm:
-                - \ref hzp_gc_classic_scan "classic_scan" allocates memory for internal use
-                - \ref hzp_gc_inplace_scan "inplace_scan" does not allocate any memory
+                    The Michael's HP reclamation schema depends of three parameters:
+                    - \p nHazardPtrCount - HP pointer count per thread. Usually it is small number (2-4) depending from
+                        the data structure algorithms. By default, if \p nHazardPtrCount = 0,
+                        the function uses maximum of HP count for CDS library
+                    - \p nMaxThreadCount - max count of thread with using HP GC in your application. Default is 100.
+                    - \p nMaxRetiredPtrCount - capacity of array of retired pointers for each thread. Must be greater than
+                        <tt> nHazardPtrCount * nMaxThreadCount </tt>
+                        Default is <tt>2 * nHazardPtrCount * nMaxThreadCount</tt>
+                */
+                static CDS_EXPORT_API void construct(
+                        size_t nHazardPtrCount = 0,     ///< Hazard pointer count per thread
+                        size_t nMaxThreadCount = 0,     ///< Max count of simultaneous working thread in your application
+                        size_t nMaxRetiredPtrCount = 0, ///< Capacity of the array of retired objects for the thread
+                        scan_type nScanType = inplace   ///< Scan type (see \ref scan_type enum)
+                );
 
-                Use \p set_scan_type() member function to setup appropriate scan algorithm.
-            */
-            void scan( thread_data* pRec )
-            {
-                pRec->sync();
-                ( this->*scan_func_ )( pRec );
-            }
+                // for back-copatibility
+                static void Construct(
+                        size_t nHazardPtrCount = 0,     ///< Hazard pointer count per thread
+                        size_t nMaxThreadCount = 0,     ///< Max count of simultaneous working thread in your application
+                        size_t nMaxRetiredPtrCount = 0, ///< Capacity of the array of retired objects for the thread
+                        scan_type nScanType = inplace   ///< Scan type (see \ref scan_type enum)
+                ) {
+                    construct(nHazardPtrCount, nMaxThreadCount, nMaxRetiredPtrCount, nScanType);
+                }
 
-            /// Helper scan routine
-            /**
-                The function guarantees that every node that is eligible for reuse is eventually freed, barring
-                thread failures. To do so, after executing \p scan(), a thread executes a \p %help_scan(),
-                where it checks every HP record. If an HP record is inactive, the thread moves all "lost" reclaimed pointers
-                to thread's list of reclaimed pointers.
+                /// Destroys global instance of \ref smr
+                /**
+                    The parameter \p bDetachAll should be used carefully: if its value is \p true,
+                    then the object destroyed automatically detaches all attached threads. This feature
+                    can be useful when you have no control over the thread termination, for example,
+                    when \p libcds is injected into existing external thread.
+                */
+                static CDS_EXPORT_API void destruct(
+                        bool bDetachAll = false     ///< Detach all threads
+                );
 
-                The function is called internally by \p scan().
-            */
-            CDS_EXPORT_API void help_scan( thread_data* pThis );
+                // for back-compatibility
+                static void Destruct(
+                        bool bDetachAll = false     ///< Detach all threads
+                ) {
+                    destruct(bDetachAll);
+                }
 
-        private:
-            CDS_EXPORT_API smr(
-                size_t nHazardPtrCount,     ///< Hazard pointer count per thread
-                size_t nMaxThreadCount,     ///< Max count of simultaneous working thread in your application
-                size_t nMaxRetiredPtrCount, ///< Capacity of the array of retired objects for the thread
-                scan_type nScanType         ///< Scan type (see \ref scan_type enum)
-            );
+                /// Checks if global SMR object is constructed and may be used
+                static bool isUsed() noexcept {
+                    return instance_ != nullptr;
+                }
 
-            CDS_EXPORT_API ~smr();
+                /// Set memory management functions
+                /**
+                    @note This function may be called <b>BEFORE</b> creating an instance
+                    of Hazard Pointer SMR
 
-            CDS_EXPORT_API void detach_all_thread();
+                    SMR object allocates some memory for thread-specific data and for
+                    creating SMR object.
+                    By default, a standard \p new and \p delete operators are used for this.
+                */
+                static CDS_EXPORT_API void set_memory_allocator(
+                        void *( *alloc_func )(size_t size),
+                        void (*free_func )(void *p)
+                );
 
-            /// Classic scan algorithm
-            /** @anchor hzp_gc_classic_scan
-                Classical scan algorithm as described in Michael's paper.
+                /// Returns max Hazard Pointer count per thread
+                size_t get_hazard_ptr_count() const noexcept {
+                    return hazard_ptr_count_;
+                }
 
-                A scan includes four stages. The first stage involves scanning the array HP for non-null values.
-                Whenever a non-null value is encountered, it is inserted in a local list of currently protected pointer.
-                Only stage 1 accesses shared variables. The following stages operate only on private variables.
+                /// Returns max thread count
+                size_t get_max_thread_count() const noexcept {
+                    return max_thread_count_;
+                }
 
-                The second stage of a scan involves sorting local list of protected pointers to allow
-                binary search in the third stage.
+                /// Returns max size of retired objects array
+                size_t get_max_retired_ptr_count() const noexcept {
+                    return max_retired_ptr_count_;
+                }
 
-                The third stage of a scan involves checking each reclaimed node
-                against the pointers in local list of protected pointers. If the binary search yields
-                no match, the node is freed. Otherwise, it cannot be deleted now and must kept in thread's list
-                of reclaimed pointers.
+                /// Get current scan strategy
+                scan_type get_scan_type() const {
+                    return scan_type_;
+                }
 
-                The forth stage prepares new thread's private list of reclaimed pointers
-                that could not be freed during the current scan, where they remain until the next scan.
+                /// Checks that required hazard pointer count \p nRequiredCount is less or equal then max hazard pointer count
+                /**
+                    If <tt> nRequiredCount > get_hazard_ptr_count()</tt> then the exception \p not_enough_hazard_ptr is thrown
+                */
+                static void check_hazard_ptr_count(size_t nRequiredCount) {
+                    if (instance().get_hazard_ptr_count() < nRequiredCount) {
+#       ifdef CDS_DISABLE_SMR_EXCEPTION
+                        assert( false );    // not enough hazard ptr
+#       else
+                        CDS_THROW_EXCEPTION(not_enough_hazard_ptr());
+#       endif
+                    }
+                }
 
-                This algorithm allocates memory for internal HP array.
+                /// Returns thread-local data for the current thread
+                static CDS_EXPORT_API thread_data *tls();
 
-                This function is called internally by ThreadGC object when upper bound of thread's list of reclaimed pointers
-                is reached.
-            */
-            CDS_EXPORT_API void classic_scan( thread_data* pRec );
+                static CDS_EXPORT_API void attach_thread();
 
-            /// In-place scan algorithm
-            /** @anchor hzp_gc_inplace_scan
-                Unlike the \p classic_scan() algorithm, \p %inplace_scan() does not allocate any memory.
-                All operations are performed in-place.
-            */
-            CDS_EXPORT_API void inplace_scan( thread_data* pRec );
+                static CDS_EXPORT_API void detach_thread();
 
-        private:
-            CDS_EXPORT_API thread_record* create_thread_data();
-            static CDS_EXPORT_API void destroy_thread_data( thread_record* pRec );
+                /// Get internal statistics
+                CDS_EXPORT_API void statistics(stat &st);
 
-            /// Allocates Hazard Pointer SMR thread private data
-            CDS_EXPORT_API thread_record* alloc_thread_data();
+            public: // for internal use only
+                /// The main garbage collecting function
+                /**
+                    This function is called internally when upper bound of thread's list of reclaimed pointers
+                    is reached.
 
-            /// Free HP SMR thread-private data
-            CDS_EXPORT_API void free_thread_data( thread_record* pRec, bool callHelpScan );
+                    There are the following scan algorithm:
+                    - \ref hzp_gc_classic_scan "classic_scan" allocates memory for internal use
+                    - \ref hzp_gc_inplace_scan "inplace_scan" does not allocate any memory
 
-        private:
-            static CDS_EXPORT_API smr* instance_;
+                    Use \p set_scan_type() member function to setup appropriate scan algorithm.
+                */
+                void scan(thread_data *pRec) {
+                    pRec->sync();
+                    (this->*scan_func_)(pRec);
+                }
 
-            atomics::atomic< thread_record*>    thread_list_;   ///< Head of thread list
+                /// Helper scan routine
+                /**
+                    The function guarantees that every node that is eligible for reuse is eventually freed, barring
+                    thread failures. To do so, after executing \p scan(), a thread executes a \p %help_scan(),
+                    where it checks every HP record. If an HP record is inactive, the thread moves all "lost" reclaimed pointers
+                    to thread's list of reclaimed pointers.
 
-            size_t const    hazard_ptr_count_;      ///< max count of thread's hazard pointer
-            size_t const    max_thread_count_;      ///< max count of thread
-            size_t const    max_retired_ptr_count_; ///< max count of retired ptr per thread
-            scan_type const scan_type_;             ///< scan type (see \ref scan_type enum)
-            void ( smr::*scan_func_ )( thread_data* pRec );
-        };
-        //@endcond
+                    The function is called internally by \p scan().
+                */
+                CDS_EXPORT_API void help_scan(thread_data *pThis);
+
+            private:
+                CDS_EXPORT_API smr(
+                        size_t nHazardPtrCount,     ///< Hazard pointer count per thread
+                        size_t nMaxThreadCount,     ///< Max count of simultaneous working thread in your application
+                        size_t nMaxRetiredPtrCount, ///< Capacity of the array of retired objects for the thread
+                        scan_type nScanType         ///< Scan type (see \ref scan_type enum)
+                );
+
+                CDS_EXPORT_API ~smr();
+
+                CDS_EXPORT_API void detach_all_thread();
+
+                /// Classic scan algorithm
+                /** @anchor hzp_gc_classic_scan
+                    Classical scan algorithm as described in Michael's paper.
+
+                    A scan includes four stages. The first stage involves scanning the array HP for non-null values.
+                    Whenever a non-null value is encountered, it is inserted in a local list of currently protected pointer.
+                    Only stage 1 accesses shared variables. The following stages operate only on private variables.
+
+                    The second stage of a scan involves sorting local list of protected pointers to allow
+                    binary search in the third stage.
+
+                    The third stage of a scan involves checking each reclaimed node
+                    against the pointers in local list of protected pointers. If the binary search yields
+                    no match, the node is freed. Otherwise, it cannot be deleted now and must kept in thread's list
+                    of reclaimed pointers.
+
+                    The forth stage prepares new thread's private list of reclaimed pointers
+                    that could not be freed during the current scan, where they remain until the next scan.
+
+                    This algorithm allocates memory for internal HP array.
+
+                    This function is called internally by ThreadGC object when upper bound of thread's list of reclaimed pointers
+                    is reached.
+                */
+                CDS_EXPORT_API void classic_scan(thread_data *pRec);
+
+                /// In-place scan algorithm
+                /** @anchor hzp_gc_inplace_scan
+                    Unlike the \p classic_scan() algorithm, \p %inplace_scan() does not allocate any memory.
+                    All operations are performed in-place.
+                */
+                CDS_EXPORT_API void inplace_scan(thread_data *pRec);
+
+            private:
+                CDS_EXPORT_API thread_record *create_thread_data();
+
+                static CDS_EXPORT_API void destroy_thread_data(thread_record *pRec);
+
+                /// Allocates Hazard Pointer SMR thread private data
+                CDS_EXPORT_API thread_record *alloc_thread_data();
+
+                /// Free HP SMR thread-private data
+                CDS_EXPORT_API void free_thread_data(thread_record *pRec, bool callHelpScan);
+
+            private:
+                static CDS_EXPORT_API smr *instance_;
+
+                atomics::atomic<thread_record *> thread_list_;   ///< Head of thread list
+
+                size_t const hazard_ptr_count_;      ///< max count of thread's hazard pointer
+                size_t const max_thread_count_;      ///< max count of thread
+                size_t const max_retired_ptr_count_; ///< max count of retired ptr per thread
+                scan_type const scan_type_;             ///< scan type (see \ref scan_type enum)
+                void ( smr::*scan_func_ )(thread_data *pRec);
+            };
+            //@endcond
+
+        } // namespace details
 
         //@cond
         // for backward compatibility
+        typedef details::smr smr;
         typedef smr GarbageCollector;
         //@endcond
-
     } // namespace hp
 
+    namespace details {
     /// Hazard Pointer SMR (Safe Memory Reclamation)
     /**  @ingroup cds_garbage_collector
 
@@ -641,7 +608,7 @@ namespace cds { namespace gc {
     {
     public:
         /// Native guarded pointer type
-        typedef hp::hazard_ptr guarded_pointer;
+        typedef hp::details::hazard_ptr guarded_pointer;
 
         /// Atomic reference
         template <typename T> using atomic_ref = atomics::atomic<T *>;
@@ -653,10 +620,10 @@ namespace cds { namespace gc {
         template <typename T> using atomic_type = atomics::atomic<T>;
 
         /// Exception "Not enough Hazard Pointer"
-        typedef hp::not_enough_hazard_ptr not_enough_hazard_ptr_exception;
+        typedef hp::details::not_enough_hazard_ptr not_enough_hazard_ptr_exception;
 
         /// Internal statistics
-        typedef hp::stat stat;
+        typedef hp::details::stat stat;
 
         /// Hazard Pointer guard
         /**
@@ -863,14 +830,14 @@ namespace cds { namespace gc {
             }
 
             //@cond
-            hp::guard* release()
+            hp::details::guard* release()
             {
-                hp::guard* g = guard_;
+                hp::details::guard* g = guard_;
                 guard_ = nullptr;
                 return g;
             }
 
-            hp::guard*& guard_ref()
+            hp::details::guard*& guard_ref()
             {
                 return guard_;
             }
@@ -878,7 +845,7 @@ namespace cds { namespace gc {
 
         private:
             //@cond
-            hp::guard* guard_;
+            hp::details::guard* guard_;
             //@endcond
         };
 
@@ -1027,7 +994,7 @@ namespace cds { namespace gc {
             }
 
             //@cond
-            hp::guard* release( size_t nIndex ) noexcept
+            hp::details::guard* release( size_t nIndex ) noexcept
             {
                 return guards_.release( nIndex );
             }
@@ -1041,7 +1008,7 @@ namespace cds { namespace gc {
 
         private:
             //@cond
-            hp::guard_array<c_nCapacity> guards_;
+            hp::details::guard_array<c_nCapacity> guards_;
             //@endcond
         };
 
@@ -1113,7 +1080,7 @@ namespace cds { namespace gc {
             {}
 
             //@cond
-            explicit guarded_ptr( hp::guard* g ) noexcept
+            explicit guarded_ptr( hp::details::guard* g ) noexcept
                 : guard_( g )
             {}
 
@@ -1249,15 +1216,15 @@ namespace cds { namespace gc {
 
         private:
             //@cond
-            hp::guard* guard_;
+            hp::details::guard* guard_;
             //@endcond
         };
 
     public:
         /// \p scan() type
         enum class scan_type {
-            classic = hp::classic,    ///< classic scan as described in Michael's papers
-            inplace = hp::inplace     ///< inplace scan without allocation
+            classic = hp::details::classic,    ///< classic scan as described in Michael's papers
+            inplace = hp::details::inplace     ///< inplace scan without allocation
         };
 
         /// Initializes %HP singleton
@@ -1284,7 +1251,7 @@ namespace cds { namespace gc {
                 nHazardPtrCount,
                 nMaxThreadCount,
                 nMaxRetiredPtrCount,
-                static_cast<hp::scan_type>(nScanType)
+                static_cast<hp::details::scan_type>(nScanType)
             );
         }
 
@@ -1352,8 +1319,8 @@ namespace cds { namespace gc {
         template <typename T>
         static void retire( T * p, void( *func )( void * ))
         {
-            hp::thread_data* rec = hp::smr::tls();
-            if ( !rec->retired_.push( hp::retired_ptr( p, func )))
+            hp::details::thread_data* rec = hp::smr::tls();
+            if ( !rec->retired_.push( hp::details::retired_ptr( p, func )))
                 hp::smr::instance().scan( rec );
         }
 
@@ -1409,7 +1376,7 @@ namespace cds { namespace gc {
         template <class Disposer, typename T>
         static void retire( T * p )
         {
-            if ( !hp::smr::tls()->retired_.push( hp::retired_ptr( p, +[]( void* p ) { Disposer()( static_cast<T*>( p )); })))
+            if ( !hp::smr::tls()->retired_.push( hp::details::retired_ptr( p, +[]( void* p ) { Disposer()( static_cast<T*>( p )); })))
                 scan();
         }
 
@@ -1497,7 +1464,10 @@ namespace cds { namespace gc {
         */
         CDS_EXPORT_API static stat const& postmortem_statistics();
     };
+    } // namespace cds::gc::details
 
+    typedef details::HP HP;
+    typedef hp::details::smr smr;
 }} // namespace cds::gc
 
 #endif // #ifndef CDSLIB_GC_HP_SMR_H

--- a/cds/gc/hp.h
+++ b/cds/gc/hp.h
@@ -349,10 +349,10 @@ namespace cds { namespace gc {
             };
             //@endcond
 
-            /// \p basic_smr::scan() strategy
+            /// \p smr::scan() strategy
             enum scan_type {
-                classic,    ///< classic scan as described in Michael's works (see basic_smr::classic_scan())
-                inplace     ///< inplace scan without allocation (see basic_smr::inplace_scan())
+                classic,    ///< classic scan as described in Michael's works (see smr::classic_scan())
+                inplace     ///< inplace scan without allocation (see smr::inplace_scan())
             };
 
             //@cond

--- a/cds/gc/hp.h
+++ b/cds/gc/hp.h
@@ -347,20 +347,20 @@ namespace cds { namespace gc {
             };
             //@endcond
 
-            /// \p smr::scan() strategy
+            /// \p basic_smr::scan() strategy
             enum scan_type {
-                classic,    ///< classic scan as described in Michael's works (see smr::classic_scan())
-                inplace     ///< inplace scan without allocation (see smr::inplace_scan())
+                classic,    ///< classic scan as described in Michael's works (see basic_smr::classic_scan())
+                inplace     ///< inplace scan without allocation (see basic_smr::inplace_scan())
             };
 
             //@cond
             /// Hazard Pointer SMR (Safe Memory Reclamation)
-            class smr {
+            class basic_smr {
                 struct thread_record;
 
             public:
-                /// Returns the instance of Hazard Pointer \ref smr
-                static smr &instance() {
+                /// Returns the instance of Hazard Pointer \ref basic_smr
+                static basic_smr &instance() {
 #       ifdef CDS_DISABLE_SMR_EXCEPTION
                     assert( instance_ != nullptr );
 #       else
@@ -401,7 +401,7 @@ namespace cds { namespace gc {
                     construct(nHazardPtrCount, nMaxThreadCount, nMaxRetiredPtrCount, nScanType);
                 }
 
-                /// Destroys global instance of \ref smr
+                /// Destroys global instance of \ref basic_smr
                 /**
                     The parameter \p bDetachAll should be used carefully: if its value is \p true,
                     then the object destroyed automatically detaches all attached threads. This feature
@@ -511,14 +511,14 @@ namespace cds { namespace gc {
                 CDS_EXPORT_API void help_scan(thread_data *pThis);
 
             private:
-                CDS_EXPORT_API smr(
+                CDS_EXPORT_API basic_smr(
                         size_t nHazardPtrCount,     ///< Hazard pointer count per thread
                         size_t nMaxThreadCount,     ///< Max count of simultaneous working thread in your application
                         size_t nMaxRetiredPtrCount, ///< Capacity of the array of retired objects for the thread
                         scan_type nScanType         ///< Scan type (see \ref scan_type enum)
                 );
 
-                CDS_EXPORT_API ~smr();
+                CDS_EXPORT_API ~basic_smr();
 
                 CDS_EXPORT_API void detach_all_thread();
 
@@ -567,7 +567,7 @@ namespace cds { namespace gc {
                 CDS_EXPORT_API void free_thread_data(thread_record *pRec, bool callHelpScan);
 
             private:
-                static CDS_EXPORT_API smr *instance_;
+                static CDS_EXPORT_API basic_smr *instance_;
 
                 atomics::atomic<thread_record *> thread_list_;   ///< Head of thread list
 
@@ -575,7 +575,7 @@ namespace cds { namespace gc {
                 size_t const max_thread_count_;      ///< max count of thread
                 size_t const max_retired_ptr_count_; ///< max count of retired ptr per thread
                 scan_type const scan_type_;             ///< scan type (see \ref scan_type enum)
-                void ( smr::*scan_func_ )(thread_data *pRec);
+                void ( basic_smr::*scan_func_ )(thread_data *pRec);
             };
             //@endcond
 
@@ -583,7 +583,7 @@ namespace cds { namespace gc {
 
         //@cond
         // for backward compatibility
-        typedef details::smr smr;
+        typedef details::basic_smr smr;
         typedef smr GarbageCollector;
         //@endcond
     } // namespace hp
@@ -1467,7 +1467,7 @@ namespace cds { namespace gc {
     } // namespace cds::gc::details
 
     typedef details::HP HP;
-    typedef hp::details::smr smr;
+    typedef hp::details::basic_smr smr;
 }} // namespace cds::gc
 
 #endif // #ifndef CDSLIB_GC_HP_SMR_H

--- a/cds/gc/hp_membar.h
+++ b/cds/gc/hp_membar.h
@@ -6,7 +6,7 @@
 #include <cds/details/defs.h>
 #include <atomic>
 
-namespace cds { namespace gc { namespace hp {
+namespace cds { namespace gc { namespace hp { namespace details {
 
     class seq_qst_membar {
     public:
@@ -115,4 +115,4 @@ namespace cds { namespace gc { namespace hp {
     typedef default_membar asymmetric_global_membar;
 #endif
 
-}}} // namespace cds::gc::hp
+}}}} // namespace cds::gc::hp::details

--- a/src/hp.cpp
+++ b/src/hp.cpp
@@ -118,7 +118,6 @@ namespace cds { namespace gc { namespace hp { namespace details {
     } // namespace
 
     /*static*/ CDS_EXPORT_API basic_smr* basic_smr::instance_ = nullptr;
-    thread_local thread_data* tls_ = nullptr;
 
     struct basic_smr::thread_record: thread_data
     {

--- a/src/hp.cpp
+++ b/src/hp.cpp
@@ -120,12 +120,6 @@ namespace cds { namespace gc { namespace hp { namespace details {
     /*static*/ CDS_EXPORT_API basic_smr* basic_smr::instance_ = nullptr;
     thread_local thread_data* tls_ = nullptr;
 
-    /*static*/ CDS_EXPORT_API thread_data* basic_smr::tls()
-    {
-        assert( tls_ != nullptr );
-        return tls_;
-    }
-
     struct basic_smr::thread_record: thread_data
     {
         // next hazard ptr record in list
@@ -309,22 +303,6 @@ namespace cds { namespace gc { namespace hp { namespace details {
             }
         }
     }
-
-    /*static*/ CDS_EXPORT_API void basic_smr::attach_thread()
-    {
-        if ( !tls_ )
-            tls_ = instance().alloc_thread_data();
-    }
-
-    /*static*/ CDS_EXPORT_API void basic_smr::detach_thread()
-    {
-        thread_data* rec = tls_;
-        if ( rec ) {
-            tls_ = nullptr;
-            instance().free_thread_data( static_cast<thread_record*>( rec ), true );
-        }
-    }
-
 
     CDS_EXPORT_API void basic_smr::inplace_scan(thread_data* pThreadRec )
     {
@@ -539,10 +517,9 @@ namespace cds { namespace gc { namespace hp { namespace details {
 #   endif
     }
 
+    cds::gc::hp::details::stat const& postmortem_statistics()
+    {
+        return s_postmortem_stat;
+    }
+
 }}}} // namespace cds::gc::hp::details
-
-CDS_EXPORT_API /*static*/ cds::gc::HP::stat const& cds::gc::HP::postmortem_statistics()
-{
-    return cds::gc::hp::details::s_postmortem_stat;
-}
-

--- a/src/hp.cpp
+++ b/src/hp.cpp
@@ -30,7 +30,7 @@
 #   define CDS_MEMBARRIER_CMD_REGISTER_PRIVATE_EXPEDITED    (1<<4)
 #endif
 
-namespace cds { namespace gc { namespace hp {
+namespace cds { namespace gc { namespace hp { namespace details {
 
     std::atomic<unsigned> shared_var_membar::shared_var_{ 0 };
 
@@ -129,7 +129,7 @@ namespace cds { namespace gc { namespace hp {
     struct smr::thread_record: thread_data
     {
         // next hazard ptr record in list
-        thread_record*                      next_ = nullptr; 
+        thread_record*                      next_ = nullptr;
         // Owner thread id; 0 - the record is free (not owned)
         atomics::atomic<cds::OS::ThreadId>  thread_id_{ cds::OS::c_NullThreadId };
         // true if record is free (not owned)
@@ -376,7 +376,7 @@ namespace cds { namespace gc { namespace hp {
             while ( pNode ) {
                 if ( pNode->thread_id_.load( atomics::memory_order_relaxed ) != cds::OS::c_NullThreadId ) {
                     thread_hp_storage& hpstg = pNode->hazards_;
-                    
+
                     for ( auto hp = hpstg.begin(), end = hpstg.end(); hp != end; ++hp ) {
                         void * hptr = hp->get( atomics::memory_order_relaxed );
                         if ( hptr ) {
@@ -539,10 +539,10 @@ namespace cds { namespace gc { namespace hp {
 #   endif
     }
 
-}}} // namespace cds::gc::hp
+}}}} // namespace cds::gc::hp::details
 
 CDS_EXPORT_API /*static*/ cds::gc::HP::stat const& cds::gc::HP::postmortem_statistics()
 {
-    return cds::gc::hp::s_postmortem_stat;
+    return cds::gc::hp::details::s_postmortem_stat;
 }
 

--- a/src/hp.cpp
+++ b/src/hp.cpp
@@ -117,16 +117,16 @@ namespace cds { namespace gc { namespace hp { namespace details {
         stat s_postmortem_stat;
     } // namespace
 
-    /*static*/ CDS_EXPORT_API smr* smr::instance_ = nullptr;
+    /*static*/ CDS_EXPORT_API basic_smr* basic_smr::instance_ = nullptr;
     thread_local thread_data* tls_ = nullptr;
 
-    /*static*/ CDS_EXPORT_API thread_data* smr::tls()
+    /*static*/ CDS_EXPORT_API thread_data* basic_smr::tls()
     {
         assert( tls_ != nullptr );
         return tls_;
     }
 
-    struct smr::thread_record: thread_data
+    struct basic_smr::thread_record: thread_data
     {
         // next hazard ptr record in list
         thread_record*                      next_ = nullptr;
@@ -140,7 +140,7 @@ namespace cds { namespace gc { namespace hp { namespace details {
         {}
     };
 
-    /*static*/ CDS_EXPORT_API void smr::set_memory_allocator(
+    /*static*/ CDS_EXPORT_API void basic_smr::set_memory_allocator(
         void* ( *alloc_func )( size_t size ),
         void( *free_func )( void * p )
     )
@@ -153,36 +153,36 @@ namespace cds { namespace gc { namespace hp { namespace details {
     }
 
 
-    /*static*/ CDS_EXPORT_API void smr::construct( size_t nHazardPtrCount, size_t nMaxThreadCount, size_t nMaxRetiredPtrCount, scan_type nScanType )
+    /*static*/ CDS_EXPORT_API void basic_smr::construct(size_t nHazardPtrCount, size_t nMaxThreadCount, size_t nMaxRetiredPtrCount, scan_type nScanType )
     {
         if ( !instance_ ) {
-            instance_ = new( s_alloc_memory(sizeof(smr))) smr( nHazardPtrCount, nMaxThreadCount, nMaxRetiredPtrCount, nScanType );
+            instance_ = new( s_alloc_memory(sizeof(basic_smr))) basic_smr(nHazardPtrCount, nMaxThreadCount, nMaxRetiredPtrCount, nScanType );
         }
     }
 
-    /*static*/ CDS_EXPORT_API void smr::destruct( bool bDetachAll )
+    /*static*/ CDS_EXPORT_API void basic_smr::destruct(bool bDetachAll )
     {
         if ( instance_ ) {
             if ( bDetachAll )
                 instance_->detach_all_thread();
 
-            instance_->~smr();
+            instance_->~basic_smr();
             s_free_memory( instance_ );
             instance_ = nullptr;
         }
     }
 
-    CDS_EXPORT_API smr::smr( size_t nHazardPtrCount, size_t nMaxThreadCount, size_t nMaxRetiredPtrCount, scan_type nScanType )
+    CDS_EXPORT_API basic_smr::basic_smr(size_t nHazardPtrCount, size_t nMaxThreadCount, size_t nMaxRetiredPtrCount, scan_type nScanType )
         : hazard_ptr_count_( nHazardPtrCount == 0 ? defaults::c_nHazardPointerPerThread : nHazardPtrCount )
         , max_thread_count_( nMaxThreadCount == 0 ? defaults::c_nMaxThreadCount : nMaxThreadCount )
         , max_retired_ptr_count_( calc_retired_size( nMaxRetiredPtrCount, hazard_ptr_count_, max_thread_count_ ))
         , scan_type_( nScanType )
-        , scan_func_( nScanType == classic ? &smr::classic_scan : &smr::inplace_scan )
+        , scan_func_( nScanType == classic ? &basic_smr::classic_scan : &basic_smr::inplace_scan )
     {
         thread_list_.store( nullptr, atomics::memory_order_release );
     }
 
-    CDS_EXPORT_API smr::~smr()
+    CDS_EXPORT_API basic_smr::~basic_smr()
     {
         CDS_DEBUG_ONLY( const cds::OS::ThreadId nullThreadId = cds::OS::c_NullThreadId; )
         CDS_DEBUG_ONLY( const cds::OS::ThreadId mainThreadId = cds::OS::get_current_thread_id();)
@@ -212,7 +212,7 @@ namespace cds { namespace gc { namespace hp { namespace details {
     }
 
 
-    CDS_EXPORT_API smr::thread_record* smr::create_thread_data()
+    CDS_EXPORT_API basic_smr::thread_record* basic_smr::create_thread_data()
     {
         size_t const guard_array_size = thread_hp_storage::calc_array_size( get_hazard_ptr_count());
         size_t const retired_array_size = retired_array::calc_array_size( get_max_retired_ptr_count());
@@ -248,7 +248,7 @@ namespace cds { namespace gc { namespace hp { namespace details {
         );
     }
 
-    /*static*/ CDS_EXPORT_API void smr::destroy_thread_data( thread_record* pRec )
+    /*static*/ CDS_EXPORT_API void basic_smr::destroy_thread_data(thread_record* pRec )
     {
         // all retired pointers must be freed
         assert( pRec->retired_.size() == 0 );
@@ -258,7 +258,7 @@ namespace cds { namespace gc { namespace hp { namespace details {
     }
 
 
-    CDS_EXPORT_API smr::thread_record* smr::alloc_thread_data()
+    CDS_EXPORT_API basic_smr::thread_record* basic_smr::alloc_thread_data()
     {
         thread_record * hprec;
         const cds::OS::ThreadId nullThreadId = cds::OS::c_NullThreadId;
@@ -286,7 +286,7 @@ namespace cds { namespace gc { namespace hp { namespace details {
         return hprec;
     }
 
-    CDS_EXPORT_API void smr::free_thread_data( smr::thread_record* pRec, bool callHelpScan )
+    CDS_EXPORT_API void basic_smr::free_thread_data(basic_smr::thread_record* pRec, bool callHelpScan )
     {
         assert( pRec != nullptr );
 
@@ -297,7 +297,7 @@ namespace cds { namespace gc { namespace hp { namespace details {
         pRec->thread_id_.store( cds::OS::c_NullThreadId, atomics::memory_order_release );
     }
 
-    CDS_EXPORT_API void smr::detach_all_thread()
+    CDS_EXPORT_API void basic_smr::detach_all_thread()
     {
         thread_record * pNext = nullptr;
         const cds::OS::ThreadId nullThreadId = cds::OS::c_NullThreadId;
@@ -310,13 +310,13 @@ namespace cds { namespace gc { namespace hp { namespace details {
         }
     }
 
-    /*static*/ CDS_EXPORT_API void smr::attach_thread()
+    /*static*/ CDS_EXPORT_API void basic_smr::attach_thread()
     {
         if ( !tls_ )
             tls_ = instance().alloc_thread_data();
     }
 
-    /*static*/ CDS_EXPORT_API void smr::detach_thread()
+    /*static*/ CDS_EXPORT_API void basic_smr::detach_thread()
     {
         thread_data* rec = tls_;
         if ( rec ) {
@@ -326,7 +326,7 @@ namespace cds { namespace gc { namespace hp { namespace details {
     }
 
 
-    CDS_EXPORT_API void smr::inplace_scan( thread_data* pThreadRec )
+    CDS_EXPORT_API void basic_smr::inplace_scan(thread_data* pThreadRec )
     {
         thread_record* pRec = static_cast<thread_record*>( pThreadRec );
 
@@ -415,7 +415,7 @@ namespace cds { namespace gc { namespace hp { namespace details {
     }
 
     // cppcheck-suppress functionConst
-    CDS_EXPORT_API void smr::classic_scan( thread_data* pThreadRec )
+    CDS_EXPORT_API void basic_smr::classic_scan(thread_data* pThreadRec )
     {
         thread_record* pRec = static_cast<thread_record*>( pThreadRec );
 
@@ -469,7 +469,7 @@ namespace cds { namespace gc { namespace hp { namespace details {
         }
     }
 
-    CDS_EXPORT_API void smr::help_scan( thread_data* pThis )
+    CDS_EXPORT_API void basic_smr::help_scan(thread_data* pThis )
     {
         assert( static_cast<thread_record*>( pThis )->thread_id_.load( atomics::memory_order_relaxed ) == cds::OS::get_current_thread_id());
 
@@ -520,7 +520,7 @@ namespace cds { namespace gc { namespace hp { namespace details {
         }
     }
 
-    CDS_EXPORT_API void smr::statistics( stat& st )
+    CDS_EXPORT_API void basic_smr::statistics(stat& st )
     {
         st.clear();
 #   ifdef CDS_ENABLE_HPSTAT

--- a/src/hp_thread_local.cpp
+++ b/src/hp_thread_local.cpp
@@ -1,0 +1,62 @@
+// Copyright (c) 2020-2020 Alexander Gaev
+//
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <cds/gc/hp.h>
+#include <map>
+
+namespace cds {
+    namespace gc {
+        namespace hp {
+            namespace details {
+                thread_local thread_data *tls_ = nullptr;
+                thread_local std::pair<thread_data *, thread_data *> *tls2_ = new std::pair<thread_data *, thread_data *>(
+                        nullptr,
+                        nullptr);
+                const size_t MAXIMUM_THREAD_ID = 100000;
+                static thread_data *heap_tls_[MAXIMUM_THREAD_ID];
+
+                /*static*/ CDS_EXPORT_API thread_data *DefaultTLSManager::getTLS() {
+                    return tls_;
+                }
+
+                /*static*/ CDS_EXPORT_API void DefaultTLSManager::setTLS(thread_data *new_tls) {
+                    tls_ = new_tls;
+                }
+
+                /*static*/ CDS_EXPORT_API thread_data *StrangeTLSManager::getTLS() {
+                    if (cds::OS::get_current_thread_id() % 2 == 0) { // % 2 with ThreadId structure?
+                        return tls2_->second;
+                    } else {
+                        return tls2_->first;
+                    }
+                }
+
+                /*static*/ CDS_EXPORT_API void StrangeTLSManager::setTLS(thread_data *new_tls) {
+                    if (cds::OS::get_current_thread_id() % 2 == 0) { // % 2 with ThreadId structure?
+                        tls2_->second = new_tls;
+                    } else {
+                        tls2_->first = new_tls;
+                    }
+                }
+
+                /*static*/ CDS_EXPORT_API thread_data *HeapTLSManager::getTLS() {
+                    cds::OS::posix::ThreadId thread_id = cds::OS::get_current_thread_id();
+                    if (thread_id < 0 || thread_id >= MAXIMUM_THREAD_ID) {
+                        throw std::runtime_error("HeapTLSManager too big thread_id");
+                    }
+                    return heap_tls_[thread_id];
+                }
+
+                /*static*/ CDS_EXPORT_API void HeapTLSManager::setTLS(thread_data *new_tls) {
+                    cds::OS::posix::ThreadId thread_id = cds::OS::get_current_thread_id();
+                    if (thread_id < 0 || thread_id >= MAXIMUM_THREAD_ID) {
+                        throw std::runtime_error("HeapTLSManager too big thread_id");
+                    }
+                    heap_tls_[thread_id] = new_tls;
+                }
+            }
+        }
+    }
+}

--- a/src/hp_thread_local.cpp
+++ b/src/hp_thread_local.cpp
@@ -43,7 +43,7 @@ namespace cds {
 
                 /*static*/ CDS_EXPORT_API thread_data *HeapTLSManager::getTLS() {
                     cds::OS::posix::ThreadId thread_id = cds::OS::get_current_thread_id();
-                    if (thread_id < 0 || thread_id >= MAXIMUM_THREAD_ID) {
+                    if (thread_id >= MAXIMUM_THREAD_ID) {
                         throw std::runtime_error("HeapTLSManager too big thread_id");
                     }
                     return heap_tls_[thread_id];
@@ -51,7 +51,7 @@ namespace cds {
 
                 /*static*/ CDS_EXPORT_API void HeapTLSManager::setTLS(thread_data *new_tls) {
                     cds::OS::posix::ThreadId thread_id = cds::OS::get_current_thread_id();
-                    if (thread_id < 0 || thread_id >= MAXIMUM_THREAD_ID) {
+                    if (thread_id >= MAXIMUM_THREAD_ID) {
                         throw std::runtime_error("HeapTLSManager too big thread_id");
                     }
                     heap_tls_[thread_id] = new_tls;


### PR DESCRIPTION
Here are some work about implementing generic Hazard Pointers.

Some summary:
```
class DefaultTLSManager {
            public:
                static CDS_EXPORT_API thread_data* getTLS();
                static CDS_EXPORT_API void setTLS(thread_data*);
            };
class StrangeTLSManager;
class HeapTLSManager;
```

```
cds::gc::hp::smr -> cds::gc::hp::details::basic_smr
template<typename TLSManager> class cds::gc::hp::details::generic_smr : public basic_smr;
cds::gc::HP -> template<typename TLSManager> cds::gc::details::generic_HP;
Guard, GuardArray, guarded_ptr are inside generic_HP so also templated by TLSManager
```

External API should use the same TLSManager template class in operations(Guards, attach/detach_thread).