### PR TITLE
add s390x platform support

### DIFF
--- a/cds/compiler/gcc/compiler_macro.h
+++ b/cds/compiler/gcc/compiler_macro.h
@@ -103,6 +103,11 @@
 #    define CDS_BUILD_BITS        64
 #    define CDS_PROCESSOR__NAME   "IBM PowerPC64"
 #    define CDS_PROCESSOR__NICK   "ppc64"
+#elif defined(__s390x__)
+#    define CDS_PROCESSOR_ARCH    CDS_PROCESSOR_S390X
+#    define CDS_BUILD_BITS        64
+#    define CDS_PROCESSOR__NAME   "IBM Z"
+#    define CDS_PROCESSOR__NICK   "s390x"
 #elif defined(__arm__) && __SIZEOF_POINTER__ == 4 && __ARM_ARCH >= 7 && __ARM_ARCH < 8
 #    define CDS_PROCESSOR_ARCH    CDS_PROCESSOR_ARM7
 #    define CDS_BUILD_BITS        32


### PR DESCRIPTION
This add minimal change to support the s390x platform. It passes all tests except 49 and 65, but those fail on other platforms as well (x86_64 and ppc64le). All builds/tests were run on Fedora 36 with gcc 12.